### PR TITLE
SonarQube warnings cleanup (Major warnings)

### DIFF
--- a/src/main/java/com/chrisnewland/jitwatch/core/HotSpotLogParser.java
+++ b/src/main/java/com/chrisnewland/jitwatch/core/HotSpotLogParser.java
@@ -112,7 +112,7 @@ public class HotSpotLogParser
 				}
 				catch (Exception ex)
 				{
-					System.err.println("Exception handling: '" + currentLine + "'");
+					System.err.format("Exception handling: '%s'", currentLine);
                     ex.printStackTrace();
 				}
 			}

--- a/src/main/java/com/chrisnewland/jitwatch/core/TagProcessor.java
+++ b/src/main/java/com/chrisnewland/jitwatch/core/TagProcessor.java
@@ -5,11 +5,12 @@
  */
 package com.chrisnewland.jitwatch.core;
 
-import java.util.Map;
-
 import com.chrisnewland.jitwatch.model.Tag;
 import com.chrisnewland.jitwatch.model.Task;
 import com.chrisnewland.jitwatch.util.StringUtil;
+
+import java.util.Map;
+
 import static com.chrisnewland.jitwatch.core.JITWatchConstants.*;
 
 public class TagProcessor
@@ -37,7 +38,7 @@ public class TagProcessor
 			}
 			else
 			{
-				System.err.println("Did not handle: " + line);
+				System.err.format("Did not handle: %s", line);
 			}
 		}
 

--- a/src/main/java/com/chrisnewland/jitwatch/demo/MakeHotSpotLog.java
+++ b/src/main/java/com/chrisnewland/jitwatch/demo/MakeHotSpotLog.java
@@ -41,7 +41,7 @@ public class MakeHotSpotLog
 			count = add(count, i);
 		}
 
-		System.out.println("addVariable: " + count);
+		System.out.format("addVariable: %d", count);
 	}
 
 	private void addConstant(int iterations)
@@ -53,7 +53,7 @@ public class MakeHotSpotLog
 			count = add(count, 1);
 		}
 
-		System.out.println("addConstant: " + count);
+		System.out.format("addConstant: %d", count);
 	}
 
 	private void randomBranchTest(int iterations)
@@ -76,7 +76,7 @@ public class MakeHotSpotLog
 			}
 		}
 
-		System.out.println("randomBranchTest: " + count + " " + adds + " " + subs);
+		System.out.format("randomBranchTest: %d %d %d", count, adds, subs);
 	}
 
 	private void changingBranchTest(int iterations)
@@ -99,7 +99,7 @@ public class MakeHotSpotLog
 			}
 		}
 
-		System.out.println("changingBranchTest: " + count + " " + adds + " " + subs);
+		System.out.format("changingBranchTest: %d %d %d", count, adds, subs);
 	}
 
 	private void intrinsicTest(int iterations)
@@ -120,7 +120,7 @@ public class MakeHotSpotLog
 			}
 		}
 
-		System.out.println("intrinsicTest: " + dstSum);
+		System.out.format("intrinsicTest: %d", dstSum);
 	}
 
 	private long add(long a, long b)
@@ -142,7 +142,7 @@ public class MakeHotSpotLog
 			count = bigMethod(count, i);
 		}
 
-		System.out.println("tooBigToInline: " + count);
+		System.out.format("tooBigToInline: %d", count);
 	}
 
 	private long bigMethod(long count, int i)
@@ -237,7 +237,7 @@ public class MakeHotSpotLog
 			}
 		}
 
-		System.out.println("list sum: " + sum);
+		System.out.format("list sum: %d", sum);
 	}
 
 	private void testCallChain(long iterations)
@@ -250,7 +250,7 @@ public class MakeHotSpotLog
 			count = chainB1(count);
 		}
 
-		System.out.println("testCallChain: " + count);
+		System.out.format("testCallChain: %d", count);
 	}
 
 	private long chainA1(long count)
@@ -300,7 +300,7 @@ public class MakeHotSpotLog
 
 		}
 
-		System.out.println("testCallChain2: " + count);
+		System.out.format("testCallChain2: %d", count);
 	}
 
 	private long chainC1(long count)
@@ -331,7 +331,7 @@ public class MakeHotSpotLog
 			}
 			catch (NumberFormatException nfe)
 			{
-				System.err.println("usage: MakeHotSpotLog [iterations]");
+				System.err.format("usage: MakeHotSpotLog [iterations]");
 			}
 		}
 

--- a/src/main/java/com/chrisnewland/jitwatch/launch/LaunchHeadless.java
+++ b/src/main/java/com/chrisnewland/jitwatch/launch/LaunchHeadless.java
@@ -5,14 +5,14 @@
  */
 package com.chrisnewland.jitwatch.launch;
 
-import java.io.File;
-import java.io.IOException;
-
+import com.chrisnewland.jitwatch.core.HotSpotLogParser;
 import com.chrisnewland.jitwatch.core.IJITListener;
 import com.chrisnewland.jitwatch.core.JITEvent;
-import com.chrisnewland.jitwatch.core.HotSpotLogParser;
 import com.chrisnewland.jitwatch.core.JITWatchConfig;
 import com.chrisnewland.jitwatch.model.JITDataModel;
+
+import java.io.File;
+import java.io.IOException;
 
 public class LaunchHeadless implements IJITListener
 {
@@ -34,7 +34,7 @@ public class LaunchHeadless implements IJITListener
 	@Override
 	public void handleLogEntry(String entry)
 	{
-		System.out.println(entry);
+		System.out.format(entry);
 	}
 
 	@Override
@@ -42,21 +42,21 @@ public class LaunchHeadless implements IJITListener
 	{
 		if (showErrors)
 		{
-			System.err.println(entry);
+			System.err.format(entry);
 		}
 	}
 
 	@Override
 	public void handleJITEvent(JITEvent event)
 	{
-		System.out.println(event.toString());
+		System.out.format(event.toString());
 	}
 
 	public static void main(String[] args) throws IOException
 	{
 		if (args.length < 1)
 		{
-			System.err.println("Usage: LaunchHeadless <hotspot log file> [logErrors (true|false)]");
+			System.err.format("Usage: LaunchHeadless <hotspot log file> [logErrors (true|false)]");
 			System.exit(-1);
 		}
 

--- a/src/main/java/com/chrisnewland/jitwatch/loader/BytecodeLoader.java
+++ b/src/main/java/com/chrisnewland/jitwatch/loader/BytecodeLoader.java
@@ -5,15 +5,15 @@
  */
 package com.chrisnewland.jitwatch.loader;
 
+import com.sun.tools.javap.JavapTask;
+import com.sun.tools.javap.JavapTask.BadArgs;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.sun.tools.javap.JavapTask;
-import com.sun.tools.javap.JavapTask.BadArgs;
 
 import static com.chrisnewland.jitwatch.core.JITWatchConstants.*;
 
@@ -54,7 +54,7 @@ public class BytecodeLoader
 		}
 		catch (BadArgs ba)
 		{
-			System.err.println("Could not obtain bytcode for class: " + fqClassName);
+			System.err.format("Could not obtain bytcode for class: %s", fqClassName);
 		}
 		catch (IOException ioe)
 		{

--- a/src/main/java/com/chrisnewland/jitwatch/suggestion/AttributeSuggestionWalker.java
+++ b/src/main/java/com/chrisnewland/jitwatch/suggestion/AttributeSuggestionWalker.java
@@ -5,21 +5,16 @@
  */
 package com.chrisnewland.jitwatch.suggestion;
 
-import static com.chrisnewland.jitwatch.core.JITWatchConstants.*;
+import com.chrisnewland.jitwatch.model.*;
+import com.chrisnewland.jitwatch.suggestion.Suggestion.SuggestionType;
+import com.chrisnewland.jitwatch.util.JournalUtil;
+import com.chrisnewland.jitwatch.util.ParseUtil;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.chrisnewland.jitwatch.model.IMetaMember;
-import com.chrisnewland.jitwatch.model.IParseDictionary;
-import com.chrisnewland.jitwatch.model.IReadOnlyJITDataModel;
-import com.chrisnewland.jitwatch.model.Journal;
-import com.chrisnewland.jitwatch.model.Tag;
-import com.chrisnewland.jitwatch.model.Task;
-import com.chrisnewland.jitwatch.suggestion.Suggestion.SuggestionType;
-import com.chrisnewland.jitwatch.util.JournalUtil;
-import com.chrisnewland.jitwatch.util.ParseUtil;
+import static com.chrisnewland.jitwatch.core.JITWatchConstants.*;
 
 public class AttributeSuggestionWalker extends AbstractSuggestionVisitable
 {
@@ -175,7 +170,7 @@ public class AttributeSuggestionWalker extends AbstractSuggestionVisitable
 				}
 				else
 				{
-					System.out.println("No score is set for reason: " + reason);
+					System.out.format("No score is set for reason: %s", reason);
 				}
 
 				StringBuilder reasonBuilder = new StringBuilder();

--- a/src/main/java/com/chrisnewland/jitwatch/ui/CompileChainStage.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/CompileChainStage.java
@@ -172,7 +172,7 @@ public class CompileChainStage extends Stage
 			@Override
 			public void handle(MouseEvent arg0)
 			{
-				System.out.println(node.getMember());
+				System.out.format("%s", node.getMember());
 			}
 		});
 

--- a/src/main/java/com/chrisnewland/jitwatch/ui/JITWatchUI.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/JITWatchUI.java
@@ -700,7 +700,7 @@ public class JITWatchUI extends Application implements IJITListener, IStageAcces
 		}
 		else
 		{
-			System.err.println("Could not open CompileChain - root node was null");
+			System.err.format("Could not open CompileChain - root node was null");
 		}
 	}
 

--- a/src/main/java/com/chrisnewland/jitwatch/ui/triview/TriView.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/triview/TriView.java
@@ -141,7 +141,7 @@ public class TriView extends Stage
 				// sometimes combo contains only selected member
 				if (!ignoreComboChanged)
 				{
-					System.out.println("combo changed. setting member: " + newVal);
+					System.out.format("combo changed. setting member: %s", newVal);
 
 					if (newVal != null)
 					{

--- a/src/main/java/com/chrisnewland/jitwatch/util/BytecodeUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/BytecodeUtil.java
@@ -5,6 +5,9 @@
  */
 package com.chrisnewland.jitwatch.util;
 
+import com.chrisnewland.jitwatch.model.IMetaMember;
+import com.chrisnewland.jitwatch.model.bytecode.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -17,14 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import com.chrisnewland.jitwatch.model.IMetaMember;
-import com.chrisnewland.jitwatch.model.bytecode.BCParamConstant;
-import com.chrisnewland.jitwatch.model.bytecode.BCParamNumeric;
-import com.chrisnewland.jitwatch.model.bytecode.BCParamString;
-import com.chrisnewland.jitwatch.model.bytecode.IBytecodeParam;
-import com.chrisnewland.jitwatch.model.bytecode.Instruction;
-import com.chrisnewland.jitwatch.model.bytecode.Opcode;
 
 import static com.chrisnewland.jitwatch.core.JITWatchConstants.*;
 
@@ -259,12 +254,12 @@ public class BytecodeUtil
 				}
 				else
 				{
-					System.out.println("could not parse bytecode: " + line);
+					System.out.format("could not parse bytecode: %s", line);
 				}
 			}
 			catch (Exception e)
 			{
-				System.out.println("Error parsing line: " + line);
+				System.out.format("Error parsing line: %s", line);
 				e.printStackTrace();
 			}
 		}

--- a/src/main/java/com/chrisnewland/jitwatch/util/JournalUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/JournalUtil.java
@@ -166,7 +166,7 @@ public class JournalUtil
 
 			if (count != 1)
 			{
-				System.out.println("Unexpected parse phase count: " + count);
+				System.out.format("Unexpected parse phase count: %d", count);
 			}
 			else
 			{

--- a/src/main/java/com/chrisnewland/jitwatch/util/ParseUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/ParseUtil.java
@@ -5,6 +5,8 @@
  */
 package com.chrisnewland.jitwatch.util;
 
+import com.chrisnewland.jitwatch.model.*;
+
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -15,14 +17,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.chrisnewland.jitwatch.core.JITWatchConstants.*;
-
-import com.chrisnewland.jitwatch.model.IMetaMember;
-import com.chrisnewland.jitwatch.model.IParseDictionary;
-import com.chrisnewland.jitwatch.model.IReadOnlyJITDataModel;
-import com.chrisnewland.jitwatch.model.MemberSignatureParts;
-import com.chrisnewland.jitwatch.model.MetaClass;
-import com.chrisnewland.jitwatch.model.PackageManager;
-import com.chrisnewland.jitwatch.model.Tag;
 
 public class ParseUtil
 {
@@ -73,7 +67,7 @@ public class ParseUtil
 		}
 		catch (ParseException pe)
 		{
-			System.err.println(pe.toString());
+			System.err.format("%s", pe.toString());
 		}
 
 		return result;

--- a/src/main/java/com/chrisnewland/jitwatch/util/UserInterfaceUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/UserInterfaceUtil.java
@@ -27,8 +27,8 @@ public class UserInterfaceUtil
         }
         else
         {
-        	//TODO make this a dialog, println too easy to miss in an IDE
-            System.err.println("If running in an IDE please add src/main/resources to your classpath");
+        	//TODO make this a dialog, format too easy to miss in an IDE
+            System.err.format("If running in an IDE please add src/main/resources to your classpath");
         }
     }
 }


### PR DESCRIPTION
This pull requestion replaced all the System.xxx.println() into System.xxx.format(). 

Do not write System.out.print - log the information instead of using System.out.print or System.out.println statement, System.xxx.format() is acceptable.
