### PR TITLE
Removed redundant {} from .error message string, fixes issue #55

### DIFF
--- a/src/main/java/com/chrisnewland/jitwatch/core/HotSpotLogParser.java
+++ b/src/main/java/com/chrisnewland/jitwatch/core/HotSpotLogParser.java
@@ -113,7 +113,7 @@ public class HotSpotLogParser
 				}
 				catch (Exception ex)
 				{
-                    logger.error("Exception handling: '{}' {}", currentLine, ex);
+                    logger.error("Exception handling: '{}'", currentLine, ex);
 				}
 			}
 			else
@@ -124,7 +124,7 @@ public class HotSpotLogParser
 				}
 				catch (InterruptedException e)
 				{
-					logger.error("{}", e);
+					logger.error("", e);
 					break;
 				}
 			}

--- a/src/main/java/com/chrisnewland/jitwatch/demo/MakeHotSpotLog.java
+++ b/src/main/java/com/chrisnewland/jitwatch/demo/MakeHotSpotLog.java
@@ -378,7 +378,7 @@ public class MakeHotSpotLog
 			}
 			catch (NumberFormatException nfe)
 			{
-                logger.error("usage: MakeHotSpotLog [iterations] {}", nfe);
+                logger.error("usage: MakeHotSpotLog [iterations]", nfe);
 			}
 		}
 

--- a/src/main/java/com/chrisnewland/jitwatch/loader/BytecodeLoader.java
+++ b/src/main/java/com/chrisnewland/jitwatch/loader/BytecodeLoader.java
@@ -63,11 +63,11 @@ public final class BytecodeLoader
 		}
 		catch (BadArgs ba)
 		{
-			logger.error("Could not obtain bytecode for class: " + fqClassName, ba);
+			logger.error("Could not obtain bytecode for class: {}", fqClassName, ba);
 		}
 		catch (IOException ioe)
 		{
-            logger.error("{}", ioe);
+            logger.error("", ioe);
 		}
 
 		if (byteCodeString != null)

--- a/src/main/java/com/chrisnewland/jitwatch/loader/ResourceLoader.java
+++ b/src/main/java/com/chrisnewland/jitwatch/loader/ResourceLoader.java
@@ -97,7 +97,7 @@ public class ResourceLoader
 			}
 			catch (IOException ioe)
 			{
-                logger.error("{}", ioe);
+                logger.error("", ioe);
 			}
 		}
 
@@ -131,7 +131,7 @@ public class ResourceLoader
 		}
 		catch (IOException ioe)
 		{
-            logger.error("{}", ioe);
+            logger.error("", ioe);
 		}
 
 		return result;

--- a/src/main/java/com/chrisnewland/jitwatch/model/JITDataModel.java
+++ b/src/main/java/com/chrisnewland/jitwatch/model/JITDataModel.java
@@ -128,7 +128,7 @@ public class JITDataModel implements IReadOnlyJITDataModel
                 }
                 catch (Throwable t)
                 {
-                    logger.error("Exception: {} {}", t.getMessage(), t);
+                    logger.error("Exception: {}", t.getMessage(), t);
                 }
             }
         }

--- a/src/main/java/com/chrisnewland/jitwatch/suggestion/AttributeSuggestionWalker.java
+++ b/src/main/java/com/chrisnewland/jitwatch/suggestion/AttributeSuggestionWalker.java
@@ -224,7 +224,7 @@ public class AttributeSuggestionWalker extends AbstractSuggestionVisitable
             }
             catch (NumberFormatException nfe)
             {
-                logger.error("{}", nfe);
+                logger.error("", nfe);
             }
         }
 
@@ -236,7 +236,7 @@ public class AttributeSuggestionWalker extends AbstractSuggestionVisitable
             }
             catch (NumberFormatException nfe)
             {
-                logger.error("{}", nfe);
+                logger.error("", nfe);
             }
         }
 

--- a/src/main/java/com/chrisnewland/jitwatch/ui/FileChooserList.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/FileChooserList.java
@@ -136,7 +136,7 @@ public class FileChooserList extends VBox
 				}
 				catch (IOException ioe)
 				{
-                    logger.error("{}", ioe);
+                    logger.error("", ioe);
 				}
 
 				lastFolder = f.getParentFile();
@@ -172,7 +172,7 @@ public class FileChooserList extends VBox
 			}
 			catch (IOException ioe)
 			{
-                logger.error("{}", ioe);
+                logger.error("", ioe);
 			}
 			
 			lastFolder = result.getParentFile();

--- a/src/main/java/com/chrisnewland/jitwatch/ui/FileChooserListSrcZip.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/FileChooserListSrcZip.java
@@ -43,7 +43,7 @@ public class FileChooserListSrcZip extends FileChooserList
 					}
 					catch (IOException ioe)
 					{
-						logger.error("{}", ioe);
+						logger.error("", ioe);
 					}
 				}
 			}

--- a/src/main/java/com/chrisnewland/jitwatch/util/ClassUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/ClassUtil.java
@@ -49,7 +49,7 @@ public final class ClassUtil
 		}
 		catch (Exception ex)
 		{
-            logger.error("Exception: {} {}", ex.getMessage(), ex);
+            logger.error("Exception: {}", ex.getMessage(), ex);
 		}
 	}
 	
@@ -67,7 +67,7 @@ public final class ClassUtil
 		}
 		catch (Exception ex)
 		{
-            logger.error("Exception: {} {}", ex.getMessage(), ex);
+            logger.error("Exception: {}", ex.getMessage(), ex);
 		}
 		
 		return null;

--- a/src/main/java/com/chrisnewland/jitwatch/util/JVMSUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/JVMSUtil.java
@@ -72,7 +72,7 @@ public class JVMSUtil
 			}
 			catch (IOException ioe)
 			{
-                logger.error("{}", ioe);
+                logger.error("", ioe);
 			}
 		}
 
@@ -117,7 +117,7 @@ public class JVMSUtil
 		}
 		catch (IOException ioe)
 		{
-            logger.error("{}", ioe);
+            logger.error("", ioe);
 		}
 	}
 

--- a/src/main/java/com/chrisnewland/jitwatch/util/NetUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/NetUtil.java
@@ -40,9 +40,9 @@ public final class NetUtil
 			}
 
 		} catch (MalformedURLException e) {
-            logger.error("{}", e);
+            logger.error("", e);
         } catch (IOException e) {
-            logger.error("{}", e);
+            logger.error("", e);
         } finally
 		{
 			if (in != null)

--- a/src/main/java/com/chrisnewland/jitwatch/util/ParseUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/ParseUtil.java
@@ -78,7 +78,7 @@ public class ParseUtil
 		}
 		catch (ParseException pe)
 		{
-            logger.error("{}", pe);
+            logger.error("", pe);
 		}
 
 		return result;
@@ -371,22 +371,22 @@ public class ParseUtil
 			}
 			catch (ClassNotFoundException cnf)
 			{
-                logger.error("ClassNotFoundException: {}", cnf);
+                logger.error("ClassNotFoundException:", cnf);
 				throw new Exception("ClassNotFoundException: " + builder.toString());
 			}
 			catch (NoClassDefFoundError ncdf)
 			{
-                logger.error("NoClassDefFoundError: {}", ncdf);
+                logger.error("NoClassDefFoundError:", ncdf);
                 throw new Exception("NoClassDefFoundError: " + builder.toString());
 			}
 			catch (Exception ex)
 			{
-                logger.error("Exception: {}", ex);
+                logger.error("Exception:", ex);
                 throw new Exception("Exception: " + ex.getMessage());
 			}
 			catch (Error err)
 			{
-                logger.error("Error: {}", err);
+                logger.error("Error:", err);
                 throw new Exception("Error: " + err.getMessage());
 			}
 
@@ -570,7 +570,7 @@ public class ParseUtil
 			}
 			else
 			{
-                logger.error("metaClass not found: " + metaClassName);
+                logger.error("metaClass not found: {}", metaClassName);
 			}
 		}
 


### PR DESCRIPTION
Removing the redundant {} from the strings in logger.error() calls, enables displaying the error object and stack trace.

Came to surface as a result of issue #55  - NumberFormatException.
