### PR TITLE
Sonar Major Warnings: Visibility Modifier

### DIFF
--- a/src/main/java/com/chrisnewland/jitwatch/core/HotSpotLogParser.java
+++ b/src/main/java/com/chrisnewland/jitwatch/core/HotSpotLogParser.java
@@ -25,7 +25,7 @@ import static com.chrisnewland.jitwatch.core.JITWatchConstants.*;
 
 public class HotSpotLogParser
 {
-	enum ParseState
+    enum ParseState
 	{
 		READY, IN_TAG, IN_NATIVE
 	}

--- a/src/main/java/com/chrisnewland/jitwatch/core/JITWatchConstants.java
+++ b/src/main/java/com/chrisnewland/jitwatch/core/JITWatchConstants.java
@@ -92,7 +92,9 @@ public final class JITWatchConstants
 
 	public static final String S_OPEN_PARENTHESES = "(";
 	public static final String S_CLOSE_PARENTHESES = ")";
-	public static final String S_OPEN_ANGLE = "<";
+    public static final String S_ENTITY_LT = "&lt;";
+    public static final String S_ENTITY_GT = "&gt;";
+    public static final String S_OPEN_ANGLE = "<";
 	public static final String S_CLOSE_ANGLE= ">";
 	public static final String S_OPEN_BRACE = "{";
 	public static final String S_CLOSE_BRACE= "}";

--- a/src/main/java/com/chrisnewland/jitwatch/histo/AbstractHistoVisitable.java
+++ b/src/main/java/com/chrisnewland/jitwatch/histo/AbstractHistoVisitable.java
@@ -4,10 +4,10 @@ import com.chrisnewland.jitwatch.model.IReadOnlyJITDataModel;
 import com.chrisnewland.jitwatch.treevisitor.TreeVisitor;
 
 public abstract class AbstractHistoVisitable implements IHistoVisitable
-{	
-	protected Histo histo;
-	protected IReadOnlyJITDataModel model;
-	protected long resolution;
+{
+    protected Histo histo;
+    protected IReadOnlyJITDataModel model;
+    protected long resolution;
 	
 	public AbstractHistoVisitable(IReadOnlyJITDataModel model, long resolution)
 	{

--- a/src/main/java/com/chrisnewland/jitwatch/model/AbstractMetaMember.java
+++ b/src/main/java/com/chrisnewland/jitwatch/model/AbstractMetaMember.java
@@ -5,6 +5,8 @@
  */
 package com.chrisnewland.jitwatch.model;
 
+import com.chrisnewland.jitwatch.model.bytecode.ClassBC;
+import com.chrisnewland.jitwatch.model.bytecode.Instruction;
 import com.chrisnewland.jitwatch.util.ParseUtil;
 import com.chrisnewland.jitwatch.util.StringUtil;
 
@@ -17,26 +19,23 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.chrisnewland.jitwatch.core.JITWatchConstants.*;
 
-import com.chrisnewland.jitwatch.model.bytecode.ClassBC;
-import com.chrisnewland.jitwatch.model.bytecode.Instruction;
-
 public abstract class AbstractMetaMember implements IMetaMember, Comparable<IMetaMember>
 {
 	protected MetaClass methodClass;
-	protected String nativeCode = null;
+    private String nativeCode = null;
 
-	protected boolean isQueued = false;
-	protected boolean isCompiled = false;
-	
-	protected Journal journal = new Journal();
+    private boolean isQueued = false;
+    private boolean isCompiled = false;
 
-	protected Map<String, String> queuedAttributes = new ConcurrentHashMap<>();
-	protected Map<String, String> compiledAttributes = new ConcurrentHashMap<>();
+    private Journal journal = new Journal();
 
-	protected int modifier; // bitset
-	protected String memberName;
-	protected Class<?> returnType;
-	protected Class<?>[] paramTypes;
+    private Map<String, String> queuedAttributes = new ConcurrentHashMap<>();
+    private Map<String, String> compiledAttributes = new ConcurrentHashMap<>();
+
+    protected int modifier; // bitset
+    protected String memberName;
+    protected Class<?> returnType;
+    protected Class<?>[] paramTypes;
 
 	private static final String anyChars = "(.*)";
 	private static final String spaceZeroOrMore = "( )*";

--- a/src/main/java/com/chrisnewland/jitwatch/suggestion/AbstractSuggestionVisitable.java
+++ b/src/main/java/com/chrisnewland/jitwatch/suggestion/AbstractSuggestionVisitable.java
@@ -1,18 +1,18 @@
 package com.chrisnewland.jitwatch.suggestion;
 
+import com.chrisnewland.jitwatch.model.IReadOnlyJITDataModel;
+import com.chrisnewland.jitwatch.treevisitor.ITreeVisitable;
+import com.chrisnewland.jitwatch.treevisitor.TreeVisitor;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import com.chrisnewland.jitwatch.model.IReadOnlyJITDataModel;
-import com.chrisnewland.jitwatch.treevisitor.ITreeVisitable;
-import com.chrisnewland.jitwatch.treevisitor.TreeVisitor;
-
 public abstract class AbstractSuggestionVisitable implements ITreeVisitable
-{	
-	protected IReadOnlyJITDataModel model;
-	protected List<Suggestion> suggestionList;
+{
+    protected IReadOnlyJITDataModel model;
+    protected List<Suggestion> suggestionList;
 	
 	public AbstractSuggestionVisitable(IReadOnlyJITDataModel model)
 	{

--- a/src/main/java/com/chrisnewland/jitwatch/toplist/AbstractTopListVisitable.java
+++ b/src/main/java/com/chrisnewland/jitwatch/toplist/AbstractTopListVisitable.java
@@ -5,19 +5,19 @@
  */
 package com.chrisnewland.jitwatch.toplist;
 
+import com.chrisnewland.jitwatch.model.IReadOnlyJITDataModel;
+import com.chrisnewland.jitwatch.treevisitor.TreeVisitor;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import com.chrisnewland.jitwatch.model.IReadOnlyJITDataModel;
-import com.chrisnewland.jitwatch.treevisitor.TreeVisitor;
-
 public abstract class AbstractTopListVisitable implements ITopListVisitable
 {
-	protected IReadOnlyJITDataModel model;
-	protected List<ITopListScore> topList;
-	protected boolean sortHighToLow;
+    protected IReadOnlyJITDataModel model;
+    protected List<ITopListScore> topList;
+    protected boolean sortHighToLow;
 
 	public AbstractTopListVisitable(IReadOnlyJITDataModel model, boolean sortHighToLow)
 	{

--- a/src/main/java/com/chrisnewland/jitwatch/ui/AbstractGraphStage.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/AbstractGraphStage.java
@@ -20,8 +20,8 @@ import javafx.stage.WindowEvent;
 public abstract class AbstractGraphStage extends Stage
 {
 	protected Canvas canvas;
-	protected GraphicsContext gc;
-	protected JITWatchUI parent;
+    protected GraphicsContext gc;
+    protected JITWatchUI parent;
 
 	protected static final double GRAPH_GAP_LEFT = 60.5;
 	protected static final double GRAPH_GAP_RIGHT = 20.5;
@@ -29,15 +29,15 @@ public abstract class AbstractGraphStage extends Stage
 
 	static final int[] Y_SCALE = new int[21];
 
-	protected double width;
-	protected double height;
-	protected double chartWidth;
-	protected double chartHeight;
+    protected double width;
+    protected double height;
+    protected double chartWidth;
+    protected double chartHeight;
 
-	protected long minX;
-	protected long maxX;
-	protected long minY;
-	protected long maxY;
+    protected long minX;
+    protected long maxX;
+    protected long minY;
+    protected long maxY;
 
 	private boolean xAxisTime = false;
 
@@ -267,5 +267,4 @@ public abstract class AbstractGraphStage extends Stage
 	{
 		return 0.5 + (int) pixel;
 	}
-
 }

--- a/src/main/java/com/chrisnewland/jitwatch/ui/ClassMemberList.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/ClassMemberList.java
@@ -260,7 +260,7 @@ public class ClassMemberList extends VBox
 
 				if (item.isCompiled())
 				{
-					setGraphic(new ImageView(UserInterfaceUtil.tick));
+					setGraphic(new ImageView(UserInterfaceUtil.getTick()));
 				}
 				else
 				{

--- a/src/main/java/com/chrisnewland/jitwatch/ui/ClassTree.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/ClassTree.java
@@ -170,9 +170,9 @@ public class ClassTree extends VBox
             hasCompiledChildren = true;
         }
 
-        if (UserInterfaceUtil.tick != null && hasCompiledChildren)
+        if (UserInterfaceUtil.getTick() != null && hasCompiledChildren)
         {
-            found.setGraphic(new ImageView(UserInterfaceUtil.tick));
+            found.setGraphic(new ImageView(UserInterfaceUtil.getTick()));
         }
 
         return found;

--- a/src/main/java/com/chrisnewland/jitwatch/ui/FileChooserList.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/FileChooserList.java
@@ -33,8 +33,8 @@ public class FileChooserList extends VBox
 	protected ListView<Label> fileList;
 
 	private File lastFolder = null;
-	
-	protected VBox vboxButtons;
+
+    protected VBox vboxButtons;
 
     public FileChooserList(Stage stage, String title, List<String> items)
 	{

--- a/src/main/java/com/chrisnewland/jitwatch/ui/triview/TriView.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/triview/TriView.java
@@ -164,9 +164,9 @@ public class TriView extends Stage
 						{
 							setText(item.toStringUnqualifiedMethodName());
 
-							if (item.isCompiled() && UserInterfaceUtil.tick != null)
+							if (item.isCompiled() && UserInterfaceUtil.getTick() != null)
 							{
-								setGraphic(new ImageView(UserInterfaceUtil.tick));
+								setGraphic(new ImageView(UserInterfaceUtil.getTick()));
 							}
 							else
 							{

--- a/src/main/java/com/chrisnewland/jitwatch/ui/triview/Viewer.java
+++ b/src/main/java/com/chrisnewland/jitwatch/ui/triview/Viewer.java
@@ -46,16 +46,16 @@ public class Viewer extends VBox
 	public static final String COLOUR_GREEN = "green";
 	public static final String COLOUR_BLUE = "blue";
 
-	protected int scrollIndex = 0;
+    private int scrollIndex = 0;
 	protected int lastScrollIndex = -1;
-	protected String originalSource;
+    protected String originalSource;
 
 	protected static final String STYLE_UNHIGHLIGHTED = "-fx-font-family:monospace; -fx-font-size:12px; -fx-background-color:white;";
 	protected static final String STYLE_HIGHLIGHTED = "-fx-font-family:monospace; -fx-font-size:12px; -fx-background-color:red;";
 
 	protected Map<Integer, LineAnnotation> lineAnnotations = new HashMap<>();
 
-	protected IStageAccessProxy stageAccessProxy;
+    protected IStageAccessProxy stageAccessProxy;
 	
 	public Viewer(IStageAccessProxy stageAccessProxy)
 	{

--- a/src/main/java/com/chrisnewland/jitwatch/util/UserInterfaceUtil.java
+++ b/src/main/java/com/chrisnewland/jitwatch/util/UserInterfaceUtil.java
@@ -16,7 +16,7 @@ public final class UserInterfaceUtil
     private static final Logger logger = LoggerFactory.getLogger(UserInterfaceUtil.class);
 
     // icon from https://www.iconfinder.com/icons/173960/tick_icon#size=16
-    public static Image tick = null;
+    private static Image tick = null;
 
     /*
         Hide Utility Class Constructor
@@ -41,5 +41,9 @@ public final class UserInterfaceUtil
         	//TODO make this a dialog, format too easy to miss in an IDE
             logger.error("If running in an IDE please add src/main/resources to your classpath");
         }
+    }
+
+    public static Image getTick() {
+        return tick;
     }
 }


### PR DESCRIPTION
- scope of fields have been reduced to private or default from protected
- getters & setters created where needed
- dummy values assigned to `S_ENTITY_LT` & `S_ENTITY_GT`, as they were missing in the last commit - needs to be corrected to appropriate values - @chriswhocodes - what should they be set to?
- Sonar has flagged a number of other fields that should stay protected as subclasses make use of them, can be considered as false positives at this instance
