### PR TITLE
Minor shell script fix

### DIFF
--- a/launchHeadless.sh
+++ b/launchHeadless.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 unamestr=`uname`
-if [ "$unamestr" = 'Darwin' ]; then
-   export JAVA_HOME=`/usr/libexec/java_home`
-else
-  if [ "$JAVA_HOME" = '' ]; then
+if [ "$JAVA_HOME" = '' ]; then
+  if [ "$unamestr" = 'Darwin' ]; then
+     export JAVA_HOME=`/usr/libexec/java_home`
+  else
      echo "JAVA_HOME has not been set."
      exit 0;
   fi

--- a/launchUI.sh
+++ b/launchUI.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 unamestr=`uname`
-if [ "$unamestr" = 'Darwin' ]; then
-   export JAVA_HOME=`/usr/libexec/java_home`
-else
-  if [ "$JAVA_HOME" = '' ]; then
+if [ "$JAVA_HOME" = '' ]; then
+  if [ "$unamestr" = 'Darwin' ]; then
+     export JAVA_HOME=`/usr/libexec/java_home`
+  else
      echo "JAVA_HOME has not been set."
      exit 0;
   fi


### PR DESCRIPTION
On Mac, if the user has set a JAVA_HOME, we should use that in preference to the system Java.
