### PR TITLE
Dynamically add urls to the DisposableClassLoader

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/core/HotSpotLogParser.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/core/HotSpotLogParser.java
@@ -265,7 +265,7 @@ public class HotSpotLogParser implements ILogParser, IMemberFinder
 		else
 		{
 			String remainder = asmProcessor.handleLine(currentLine);
-			
+
 			// handle next <nmethod appearing on last line of assembly
 			if (remainder != null)
 			{
@@ -343,24 +343,24 @@ public class HotSpotLogParser implements ILogParser, IMemberFinder
 	{
 		return threadName == null;
 	}
-	
+
 	public IMetaMember findMemberWithSignature(String logSignature)
 	{
 		IMetaMember result = null;
-		
+
 		try
 		{
 			result = ParseUtil.findMemberWithSignature(model, logSignature);
 		}
 		catch (Exception ex)
-		{			
+		{
 		}
-		
+
 		if (result == null)
 		{
 			logError("Could not parse line " + currentLineNumber + " : " + logSignature);
 		}
-		
+
 		return result;
 	}
 
@@ -522,20 +522,26 @@ public class HotSpotLogParser implements ILogParser, IMemberFinder
 		}
 
 		String fqClassName = StringUtil.getSubstringBetween(inCurrentLine, LOADED, S_SPACE);
+		int offset = inCurrentLine.indexOf("from");
+		String location = null;
+		if (offset != -1)
+			location = inCurrentLine.substring(offset + "from ".length(), inCurrentLine.length() - 1);
+		if (location != null && location.startsWith("file:"))
+			location = location.substring("file:".length());
 
 		if (fqClassName != null)
 		{
-			addToClassModel(fqClassName);
+			addToClassModel(fqClassName, location);
 		}
 	}
 
-	private void addToClassModel(String fqClassName)
+	private void addToClassModel(String fqClassName, String location)
 	{
 		Class<?> clazz = null;
 
 		try
 		{
-			clazz = ClassUtil.loadClassWithoutInitialising(fqClassName);
+			clazz = ClassUtil.loadClassWithoutInitialising(fqClassName, location);
 
 			if (clazz != null)
 			{


### PR DESCRIPTION
Problem

When running an application/benchmark on the same machine than JITWatch,
it's un-convenient to have to specify the location of the all the jars that
you just run. (The information is already present in the log file.)

Solution

Use the information found in the hotspot log, and dynamically add new
urls to the DisposableClassLoader.

Extract the path of the jar from line like this:
[Loaded java.lang.ClassLoader from /Library/Java/JavaVirtualMachines/jdk1.7.0_65.jdk/Contents/Home/jre/lib/rt.jar]

Result

In case you run the code on the same machine than JITWatch -> Less configuration.
In the other case -> no changes.
