### PR TITLE
Resolve OS dependent java and javac reference.

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/sandbox/SandboxStage.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/sandbox/SandboxStage.java
@@ -644,8 +644,9 @@ public class SandboxStage extends Stage implements ISandboxStage, IStageCloseLis
 
 		if (!vmLanguageList.contains(JITWatchConstants.VM_LANGUAGE_JAVA))
 		{
-			String javaCompiler = Paths.get(System.getProperty("java.home"), "..", "bin", "javac").toString();
-			String javaRuntime = Paths.get(System.getProperty("java.home"), "bin", "java").toString();
+			String suffix = System.getProperty("os.name").contains("Windows") ? ".exe" : "";
+			String javaCompiler = Paths.get(System.getProperty("java.home"), "..", "bin", "javac" + suffix).toString();
+			String javaRuntime = Paths.get(System.getProperty("java.home"), "bin", "java" + suffix).toString();
 
 			config.addOrUpdateVMLanguage(VM_LANGUAGE_JAVA, javaCompiler, javaRuntime);
 			config.saveConfig();

--- a/src/test/java/org/adoptopenjdk/jitwatch/test/TestCompilationUtil.java
+++ b/src/test/java/org/adoptopenjdk/jitwatch/test/TestCompilationUtil.java
@@ -70,12 +70,13 @@ public class TestCompilationUtil
 
 			List<File> sources = new ArrayList<>();
 			sources.add(f);
-			
-			File javacFile = Paths.get(System.getProperty("java.home"), "..", "bin", "javac").toFile();
+
+			String javac = System.getProperty("os.name").contains("Windows") ? "javac.exe" : "javac";
+			File javacFile = Paths.get(System.getProperty("java.home"), "..", "bin", javac).toFile();
 			
 			if (!javacFile.exists())
 			{
-				javacFile = Paths.get(System.getProperty("java.home"), "bin", "javac").toFile();
+				javacFile = Paths.get(System.getProperty("java.home"), "bin", javac).toFile();
 			}
 
 			String javaCompiler = javacFile.toString();


### PR DESCRIPTION
TestCompilationUtil::testCompileSimple fails due to a hard-coded reference to _javac_ which is _javac.exe_ under Windows. Also, the Sandbox suggests UNIX-styled references to java.exe and javac.exe under Windows what does not break the execution but what is _less correct_ than referencing Windows executables.
