### PR TITLE
Loading bytecode of classes with generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ jitwatch.log
 TEST-com.chrisnewland.jitwatch.test.*.txt
 JVMS.css
 JVMS.html
+jitwatch.out
+jitwatch.properties
+.idea
+jitwatch.iml

--- a/src/test/java/org/adoptopenjdk/jitwatch/test/TestBytecodeLoader.java
+++ b/src/test/java/org/adoptopenjdk/jitwatch/test/TestBytecodeLoader.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.adoptopenjdk.jitwatch.loader.BytecodeLoader;
@@ -637,6 +638,52 @@ public class TestBytecodeLoader
 		List<BytecodeInstruction> instructions = memberBytecode.getInstructions();
 
 		assertEquals(43, instructions.size());
+	}
+
+	@Test
+	public void testLoadingClassWithGenericReturnTypes() throws Exception
+	{
+		String fqClassName = ClassWithGenerics.class.getName();
+		String fqRunnableName = Runnable.class.getName();
+		ClassBC classByteCode = BytecodeLoader.fetchBytecodeForClass(
+				new ArrayList<String>(), fqClassName);
+
+		MemberSignatureParts msp = MemberSignatureParts.fromParts(
+				fqClassName, "getWithGenericReturnType", fqRunnableName, new ArrayList<String>());
+
+		MemberBytecode memberBytecode = classByteCode.getMemberBytecodeForSignature(msp);
+
+		List<BytecodeInstruction> instructions = memberBytecode.getInstructions();
+		// 0: aconst_null
+		// 1: areturn
+		assertEquals(2, instructions.size());
+	}
+
+	@Test
+	public void testLoadingClassWithGenericParameterTypes() throws Exception {
+		String fqClassName = ClassWithGenerics.class.getName();
+		String fqRunnableName = Runnable.class.getName();
+		ClassBC classByteCode = BytecodeLoader.fetchBytecodeForClass(
+				new ArrayList<String>(), fqClassName);
+
+		MemberSignatureParts msp = MemberSignatureParts.fromParts(
+				fqClassName, "setWithGenericParameter", "V", Arrays.asList(fqRunnableName));
+
+		MemberBytecode memberBytecode = classByteCode.getMemberBytecodeForSignature(msp);
+
+		List<BytecodeInstruction> instructions = memberBytecode.getInstructions();
+		// 0: return
+		assertEquals(1, instructions.size());
+	}
+
+	@SuppressWarnings("unused")
+	private static class ClassWithGenerics<T extends Runnable> {
+		T getWithGenericReturnType() {
+			return null;
+		}
+
+		void setWithGenericParameter(T param) {
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This bug is bugging me. The tests show that the parsing of `javap` output for both methods with generic return types, and methods with generic parameter types, is wrong. It parses the types as their type-parameter identifier, where it should parse the erased type instead, because that's a class name that can be loaded. This breaks loading bytecode for the TriView for the generic classes, and it breaks the Compile Chain view for methods that make use of the generic classes.

I looked into fixing the parser in BytecodeLoader but it's... involved. Therefor, this PR only has the failing tests.