### PR TITLE
Improve scrolling behaviour in TriView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ jitwatch.log
 TEST-com.chrisnewland.jitwatch.test.*.txt
 JVMS.css
 JVMS.html
+jitwatch.out
+jitwatch.properties
+.idea
+jitwatch.iml

--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/Viewer.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/Viewer.java
@@ -152,8 +152,9 @@ public class Viewer extends VBox
 					handleKeyPageDown();
 					break;
 				default:
-					break;
+					return;
 				}
+				event.consume();
 			}
 		};
 
@@ -541,14 +542,17 @@ public class Viewer extends VBox
 		{
 			double scrollMin = scrollPane.getVmin();
 			double scrollMax = scrollPane.getVmax();
+			double scrollPaneHeight = scrollPane.getHeight();
+			double lineHeight = vBoxRows.getChildren().get(0).getBoundsInParent().getHeight();
+			double visibleLines = scrollPaneHeight / lineHeight;
 
-			double count = vBoxRows.getChildren().size() - 1;
+			double count = vBoxRows.getChildren().size() - visibleLines;
 
 			double scrollPercent = 0;
 
 			if (count > 0)
 			{
-				scrollPercent = scrollIndex / count;
+				scrollPercent = Math.max(scrollIndex - (visibleLines / 2), 0) / count;
 			}
 
 			double scrollPos = scrollPercent * (scrollMax - scrollMin);


### PR DESCRIPTION
We now scroll such that the line in focus ends up more or less in the vertical centre of the scroll panel.

We also now consume the key event, such that the default scrolling behaviour of the ScrollPanel is bypassed.