### PR TITLE
Avoid NPE if Suggestion has null caller.

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/suggestion/MemberTableCell.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/suggestion/MemberTableCell.java
@@ -52,7 +52,7 @@ public class MemberTableCell extends TableCell<SuggestTableRow, Suggestion>
 	@Override
 	protected void updateItem(final Suggestion suggestion, boolean empty)
 	{
-		if (suggestion != null)
+		if (suggestion != null && suggestion.getCaller() != null)
 		{
 			final IMetaMember member = suggestion.getCaller();
 


### PR DESCRIPTION
I added this to avoid hanging jitwatch when I opened the Suggestions view. I haven't looked further as to why the caller was null.