### PR TITLE
TriViewer option to enforce 'keyboard mode'.

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyUtil.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyUtil.java
@@ -30,6 +30,7 @@ public final class AssemblyUtil
 	public static AssemblyMethod parseAssembly(final String asm)
 	{
 		AssemblyMethod method = new AssemblyMethod();
+		final AssemblyLabels labels = new AssemblyLabels();
 
 		String[] lines = asm.split(S_NEWLINE);
 
@@ -85,7 +86,7 @@ public final class AssemblyUtil
 			}
 			else
 			{
-				AssemblyInstruction instr = createInstruction(trimmedLine);
+				AssemblyInstruction instr = createInstruction(labels, trimmedLine);
 
 				if (instr != null)
 				{
@@ -100,10 +101,13 @@ public final class AssemblyUtil
 
 		method.setHeader(headerBuilder.toString());
 
+		labels.buildLabels();
+
 		return method;
 	}
 
-	public static AssemblyInstruction createInstruction(final String inLine)
+	public static AssemblyInstruction createInstruction(
+		final AssemblyLabels labels, final String inLine)
 	{
 		if (DEBUG_LOGGING_ASSEMBLY)
 		{
@@ -179,7 +183,8 @@ public final class AssemblyUtil
 
 				addValidOperandsToList(operands, opString);
 
-				instr = new AssemblyInstruction(annotation, addressValue, modifier, mnemonic, operands, comment);
+				instr = new AssemblyInstruction(annotation, addressValue, modifier, mnemonic, operands, comment, labels);
+				labels.newInstruction(instr);
 			}
 		}
 		else
@@ -190,7 +195,7 @@ public final class AssemblyUtil
 		return instr;
 	}
 
-	private static long getValueFromAddress(final String address)
+	static long getValueFromAddress(final String address)
 	{
 		long addressValue = 0;
 

--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/AbstractTextViewerStage.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/AbstractTextViewerStage.java
@@ -12,6 +12,7 @@ import org.adoptopenjdk.jitwatch.ui.triview.Viewer;
 
 import javafx.event.EventHandler;
 import javafx.scene.Scene;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;

--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/JournalViewerStage.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/JournalViewerStage.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import javafx.event.EventHandler;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.paint.Color;
 import javafx.stage.WindowEvent;

--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/TextViewerStage.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/TextViewerStage.java
@@ -12,6 +12,7 @@ import org.adoptopenjdk.jitwatch.util.StringUtil;
 
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.*;
 import javafx.event.EventHandler;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.stage.WindowEvent;
 

--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/TriView.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/TriView.java
@@ -88,6 +88,7 @@ public class TriView extends Stage implements ITriView, ILineListener
 	private CheckBox checkSource;
 	private CheckBox checkBytecode;
 	private CheckBox checkAssembly;
+	private CheckBox forceKeyboardMode;
 
 	private Button btnCompileChain;
 	private Button btnJITJournal;
@@ -134,6 +135,8 @@ public class TriView extends Stage implements ITriView, ILineListener
 		checkSource.setSelected(true);
 		checkBytecode.setSelected(true);
 		checkAssembly.setSelected(true);
+
+                forceKeyboardMode = new CheckBox("Keyboard mode");
 
 		ChangeListener<Boolean> checkListener = new ChangeListener<Boolean>()
 		{
@@ -188,6 +191,7 @@ public class TriView extends Stage implements ITriView, ILineListener
 		hBoxToolBarButtons.getChildren().add(checkAssembly);
 		hBoxToolBarButtons.getChildren().add(btnCompileChain);
 		hBoxToolBarButtons.getChildren().add(btnJITJournal);
+                hBoxToolBarButtons.getChildren().add(forceKeyboardMode);
 		hBoxToolBarButtons.getChildren().add(spacerTop);
 		hBoxToolBarButtons.getChildren().add(memberInfo);
 
@@ -246,9 +250,9 @@ public class TriView extends Stage implements ITriView, ILineListener
 		Scene scene = new Scene(vBox, JITWatchUI.WINDOW_WIDTH, JITWatchUI.WINDOW_HEIGHT);
 		navigationStack = new TriViewNavigationStack(this, scene);
 
-		viewerSource = new ViewerSource(parent, this, LineType.SOURCE);
-		viewerBytecode = new ViewerBytecode(parent, navigationStack, parent.getJITDataModel(), this, LineType.BYTECODE);
-		viewerAssembly = new ViewerAssembly(parent, this, LineType.ASSEMBLY);
+		viewerSource = new ViewerSource(parent, this, LineType.SOURCE, forceKeyboardMode);
+		viewerBytecode = new ViewerBytecode(parent, navigationStack, parent.getJITDataModel(), this, LineType.BYTECODE, forceKeyboardMode);
+		viewerAssembly = new ViewerAssembly(parent, this, LineType.ASSEMBLY, forceKeyboardMode);
 
 		paneSource = new TriViewPane("Source", viewerSource);
 		paneBytecode = new TriViewPane("Bytecode (double click for JVM spec)", viewerBytecode);

--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/assembly/ViewerAssembly.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/assembly/ViewerAssembly.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javafx.scene.Node;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 
@@ -40,9 +41,9 @@ import org.adoptopenjdk.jitwatch.util.StringUtil;
 
 public class ViewerAssembly extends Viewer
 {
-	public ViewerAssembly(IStageAccessProxy stageAccessProxy, ILineListener lineListener, LineType lineType)
+	public ViewerAssembly(IStageAccessProxy stageAccessProxy, ILineListener lineListener, LineType lineType, CheckBox forceKeyboardMode)
 	{
-		super(stageAccessProxy, lineListener, lineType, true);
+		super(stageAccessProxy, lineListener, lineType, true, forceKeyboardMode);
 	}
 
 	public void setAssemblyMethod(AssemblyMethod asmMethod)

--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/bytecode/ViewerBytecode.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/bytecode/ViewerBytecode.java
@@ -6,7 +6,6 @@
 package org.adoptopenjdk.jitwatch.ui.triview.bytecode;
 
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.*;
-import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.S_NEWLINE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,6 +14,7 @@ import java.util.Map;
 
 import javafx.application.Platform;
 import javafx.event.EventHandler;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseButton;
@@ -51,9 +51,9 @@ public class ViewerBytecode extends Viewer
 	private Suggestion lastSuggestion = null;
 
 	public ViewerBytecode(IStageAccessProxy stageAccessProxy, TriViewNavigationStack navigationStack, IReadOnlyJITDataModel model,
-			ILineListener lineListener, LineType lineType)
+			ILineListener lineListener, LineType lineType, CheckBox forceKeyboardMode)
 	{
-		super(stageAccessProxy, lineListener, lineType, true);
+		super(stageAccessProxy, lineListener, lineType, true, forceKeyboardMode);
 		this.model = model;
 		this.navigationStack = navigationStack;
 	}

--- a/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/source/ViewerSource.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/ui/triview/source/ViewerSource.java
@@ -5,6 +5,8 @@
  */
 package org.adoptopenjdk.jitwatch.ui.triview.source;
 
+import javafx.scene.control.CheckBox;
+
 import org.adoptopenjdk.jitwatch.ui.IStageAccessProxy;
 import org.adoptopenjdk.jitwatch.ui.triview.ILineListener;
 import org.adoptopenjdk.jitwatch.ui.triview.Viewer;
@@ -12,8 +14,8 @@ import org.adoptopenjdk.jitwatch.ui.triview.ILineListener.LineType;
 
 public class ViewerSource extends Viewer
 {
-	public ViewerSource(IStageAccessProxy stageAccessProxy, ILineListener lineListener, LineType lineType)
+	public ViewerSource(IStageAccessProxy stageAccessProxy, ILineListener lineListener, LineType lineType, CheckBox forceKeyboardMode)
 	{
-		super(stageAccessProxy, lineListener, lineType, true);
+		super(stageAccessProxy, lineListener, lineType, true, forceKeyboardMode);
 	}
 }

--- a/src/test/java/org/adoptopenjdk/jitwatch/test/TestAssemblyUtil.java
+++ b/src/test/java/org/adoptopenjdk/jitwatch/test/TestAssemblyUtil.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyBlock;
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyInstruction;
+import org.adoptopenjdk.jitwatch.model.assembly.AssemblyLabels;
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyMethod;
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyUtil;
 import org.junit.Test;
@@ -127,7 +128,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007f4475904140: mov  0x8(%rsi),%r10d ;comment";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(), line);
 		
 		assertNotNull(instr);
 		
@@ -150,7 +151,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007f447590414d: data32 xchg %ax,%ax";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(),line);
 		
 		assertNotNull(instr);
 		
@@ -175,7 +176,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007f447590416e: hlt";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(), line);
 		
 		assertNotNull(instr);
 		
@@ -197,7 +198,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007fbbc41082e5: data32 data32 nopw 0x0(%rax,%rax,1)";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(), line);
 		
 		assertNotNull(instr);
 		
@@ -219,7 +220,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007f54f9bfd2f0: mov    %eax,-0x14000(%rsp)";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(), line);
 		
 		assertNotNull(instr);
 		

--- a/src/test/java/org/adoptopenjdk/jitwatch/test/TestFindOptimizedVirtualCall.java
+++ b/src/test/java/org/adoptopenjdk/jitwatch/test/TestFindOptimizedVirtualCall.java
@@ -23,6 +23,7 @@ import org.adoptopenjdk.jitwatch.model.JITDataModel;
 import org.adoptopenjdk.jitwatch.model.MemberSignatureParts;
 import org.adoptopenjdk.jitwatch.model.MetaClass;
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyInstruction;
+import org.adoptopenjdk.jitwatch.model.assembly.AssemblyLabels;
 import org.adoptopenjdk.jitwatch.model.bytecode.BytecodeInstruction;
 import org.adoptopenjdk.jitwatch.model.bytecode.ClassBC;
 import org.adoptopenjdk.jitwatch.model.bytecode.MemberBytecode;
@@ -45,7 +46,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = S_EMPTY;
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -74,7 +75,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = null;
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -103,7 +104,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = "; Every day sends future a past.";
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -132,7 +133,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = "; - FooClass::fooMethod@1 (line 42)";
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -160,7 +161,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = C_SEMICOLON + S_OPTIMIZED_VIRTUAL_CALL;
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -189,7 +190,7 @@ public class TestFindOptimizedVirtualCall
 
 		String comment0 = " ; OopMap{rbp=Oop off=940}";
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, comment0);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, comment0, new AssemblyLabels());
 		ins.addCommentLine(";*invokevirtual toString");
 		ins.addCommentLine(callSiteComment);
 		ins.addCommentLine("; " + S_OPTIMIZED_VIRTUAL_CALL);
@@ -275,7 +276,7 @@ public class TestFindOptimizedVirtualCall
 				.getOptimizedVirtualCallSiteOrNull());
 	}
 
-	private static final int sourceLine = 282; // update if call to test2() changes line!
+	private static final int sourceLine = 283; // update if call to test2() changes line!
 
 	public void test1()
 	{
@@ -310,7 +311,7 @@ public class TestFindOptimizedVirtualCall
 		String comment2 = "; - " + fqClassName + "::" + callerMethod + "@" + vCallBCI + " (line " + sourceLine + ")";
 		String comment3 = ";  " + JITWatchConstants.S_OPTIMIZED_VIRTUAL_CALL;
 
-		AssemblyInstruction instruction = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, comment0);
+		AssemblyInstruction instruction = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, comment0, new AssemblyLabels());
 		instruction.addCommentLine(comment1);
 		instruction.addCommentLine(comment2);
 		instruction.addCommentLine(comment3);


### PR DESCRIPTION
I find the "selected line follows mouse" behaviour annoying. This patch makes it optional.