### PR TITLE
Method local symbolic labels.

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyLabels.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyLabels.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2013, 2014 Chris Newland.
+ * Copyright (c) 2015 Philip Aston
+ * Licensed under https://github.com/AdoptOpenJDK/jitwatch/blob/master/LICENSE-BSD
+ * Instructions: https://github.com/AdoptOpenJDK/jitwatch/wiki
+ */
+package org.adoptopenjdk.jitwatch.model.assembly;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.*;
+import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.S_COMMA;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.adoptopenjdk.jitwatch.util.StringUtil;
+
+/**
+ * Calculate symbolic names for method-local addresses.
+ * 
+ * <p>
+ * Operates in two modes. During parsing, {@link #newInstruction()} accumulates
+ * addresses used by instructions. After all the instructions have been parsed,
+ * {@link #buildLabels()} builds an index of addresses of all known instructions
+ * to label numbers, and {@link #formatAddress} and {@link #formatOperands}
+ * replace matching addresses with their labels.
+ *
+ * @author Philip Aston
+ */
+public final class AssemblyLabels
+{
+	private SortedSet<Long> addresses = new TreeSet<>();
+	private final Map<Long, Short> labels = new HashMap<>();
+	
+	private long lowest = Long.MAX_VALUE;
+	private long highest;
+
+	public void newInstruction(AssemblyInstruction instruction)
+	{
+		final long address = instruction.getAddress();
+		
+		lowest = min(lowest, address);
+		highest = max(highest, address);
+		
+		final Long l = instructionToLabel(instruction);
+		
+		if (l != null) {
+			addresses.add(l);
+		}
+	}
+
+	private Long instructionToLabel(AssemblyInstruction instruction)
+	{
+		final List<String> operands = instruction.getOperands();
+	
+		if (instruction.getMnemonic().startsWith("j") &&
+			operands.size() == 1) {
+			
+			return AssemblyUtil.getValueFromAddress(operands.get(0));
+		}
+		
+		return null;
+	}
+
+	public void buildLabels()
+	{
+		short next = 0;
+		
+		if (lowest != Long.MAX_VALUE)
+		{
+			for (Long a : addresses.subSet(lowest, highest + 1))
+			{
+				labels.put(a, next++);
+			}
+		}
+		
+		addresses = null;
+	}
+	
+	public void formatAddress(long address, StringBuilder builder)
+	{
+		final Short label = labels.get(address);
+		
+		if (label != null)
+		{
+			builder.append(StringUtil.pad(String.format("L%04x", label), 18, ' ', true));
+		}
+		else 
+		{
+			builder.append(S_ASSEMBLY_ADDRESS);
+			builder.append(StringUtil.pad(Long.toHexString(address), 16, '0', true));
+		}
+	}
+
+	public void formatOperands(
+		AssemblyInstruction instruction, StringBuilder builder) {
+		
+		final Long address = instructionToLabel(instruction);
+		final Short label = labels.get(address);
+		
+		if (label != null)
+		{
+			builder.append(C_SPACE);
+			builder.append(String.format("L%04x", label));
+		}
+		else
+		{
+			final List<String> operands = instruction.getOperands();
+
+			if (operands.size() > 0)
+			{
+				builder.append(C_SPACE);
+
+				for (String op : operands)
+				{
+					builder.append(op).append(S_COMMA);
+				}
+
+				builder.deleteCharAt(builder.length() - 1);
+			}
+		}
+	}
+}

--- a/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyUtil.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyUtil.java
@@ -30,6 +30,7 @@ public final class AssemblyUtil
 	public static AssemblyMethod parseAssembly(final String asm)
 	{
 		AssemblyMethod method = new AssemblyMethod();
+		final AssemblyLabels labels = new AssemblyLabels();
 
 		String[] lines = asm.split(S_NEWLINE);
 
@@ -85,7 +86,7 @@ public final class AssemblyUtil
 			}
 			else
 			{
-				AssemblyInstruction instr = createInstruction(trimmedLine);
+				AssemblyInstruction instr = createInstruction(labels, trimmedLine);
 
 				if (instr != null)
 				{
@@ -100,10 +101,13 @@ public final class AssemblyUtil
 
 		method.setHeader(headerBuilder.toString());
 
+		labels.buildLabels();
+
 		return method;
 	}
 
-	public static AssemblyInstruction createInstruction(final String inLine)
+	public static AssemblyInstruction createInstruction(
+		final AssemblyLabels labels, final String inLine)
 	{
 		if (DEBUG_LOGGING_ASSEMBLY)
 		{
@@ -179,7 +183,8 @@ public final class AssemblyUtil
 
 				addValidOperandsToList(operands, opString);
 
-				instr = new AssemblyInstruction(annotation, addressValue, modifier, mnemonic, operands, comment);
+				instr = new AssemblyInstruction(annotation, addressValue, modifier, mnemonic, operands, comment, labels);
+				labels.newInstruction(instr);
 			}
 		}
 		else
@@ -190,7 +195,7 @@ public final class AssemblyUtil
 		return instr;
 	}
 
-	private static long getValueFromAddress(final String address)
+	static long getValueFromAddress(final String address)
 	{
 		long addressValue = 0;
 

--- a/src/test/java/org/adoptopenjdk/jitwatch/test/TestAssemblyLabels.java
+++ b/src/test/java/org/adoptopenjdk/jitwatch/test/TestAssemblyLabels.java
@@ -1,0 +1,174 @@
+package org.adoptopenjdk.jitwatch.test;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+
+import org.adoptopenjdk.jitwatch.model.assembly.AssemblyInstruction;
+import org.adoptopenjdk.jitwatch.model.assembly.AssemblyLabels;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AssemblyLabels}.
+ *
+ * @author Philip Aston
+ * @since 5.2
+ */
+public class TestAssemblyLabels
+{
+	private AssemblyLabels labels = new AssemblyLabels();
+	private final StringBuilder sb = new StringBuilder();
+
+	@Test
+	public void testFormatEmpty()
+	{
+		final AssemblyInstruction localJump =
+			new AssemblyInstruction(null, 65535, null, "jne", asList("0x000000000000ffff"), null, labels);
+		
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+		sb.setLength(0);
+		labels.formatOperands(localJump, sb);
+		assertEquals(" 0x000000000000ffff", sb.toString());
+
+		labels.buildLabels();
+
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+		sb.setLength(0);
+		labels.formatOperands(localJump, sb);
+		assertEquals(" 0x000000000000ffff", sb.toString());
+	}
+	
+	@Test
+	public void testFormatJumpLocal()
+	{
+		final AssemblyInstruction localJump =
+			new AssemblyInstruction(null, 65535, null, "jne", asList("0x000000000000ffff"), null, labels);
+
+		labels.newInstruction(localJump);
+
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+		sb.setLength(0);
+		labels.formatOperands(localJump, sb);
+		assertEquals(" 0x000000000000ffff", sb.toString());
+
+		labels.buildLabels();
+		
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("             L0000", sb.toString());
+		sb.setLength(0);
+		labels.formatOperands(localJump, sb);
+		assertEquals(" L0000", sb.toString());
+	}
+
+	@Test
+	public void testFormatAddressJumpLocal2()
+	{
+		labels.newInstruction(new AssemblyInstruction("", 99, "", "blah", Collections.<String>emptyList(), "", labels));
+		labels.newInstruction(
+			new AssemblyInstruction("anno", 65534, "mod", "jne", asList("0x0000000000000100"), "", labels));
+		labels.newInstruction(
+			new AssemblyInstruction("anno", 65535, "mod", "jne", asList("0x0000000000001000"), "", labels));
+
+		sb.setLength(0);
+		labels.formatAddress(256, sb);
+		assertEquals("0x0000000000000100", sb.toString());
+		sb.setLength(0);
+		labels.formatAddress(4096, sb);
+		assertEquals("0x0000000000001000", sb.toString());
+
+		labels.buildLabels();
+
+		sb.setLength(0);
+		labels.formatAddress(256, sb);
+		assertEquals("             L0000", sb.toString());
+		sb.setLength(0);
+		labels.formatAddress(4096, sb);
+		assertEquals("             L0001", sb.toString());
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+	}
+
+	@Test
+	public void testFormatAddressJumpForeign()
+	{
+		labels.newInstruction(
+			new AssemblyInstruction("anno", 65535, "mod", "jne", asList("0x0000000000000000"), "", labels));
+
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+
+		labels.buildLabels();
+		
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+	}
+	
+	@Test
+	public void testFormatAddressNotJump()
+	{
+		labels.newInstruction(
+			new AssemblyInstruction("anno", 65535, "mod", "foo", asList("0x0000000000000000"), "", labels));
+
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+
+		labels.buildLabels();
+
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+	}
+	
+	@Test
+	public void testFormatAddressNotJump2()
+	{
+		labels.newInstruction(
+			new AssemblyInstruction("anno", 65535, "mod", "jjj", asList("1", "2"), "", labels));
+
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+
+		labels.buildLabels();
+
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+	}
+
+	@Test
+	public void testFormatNoOperands()
+	{
+		final AssemblyInstruction noOps =
+			new AssemblyInstruction(null, 65535, null, "jne", Collections.<String>emptyList(), null, labels);
+		
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+		sb.setLength(0);
+		labels.formatOperands(noOps, sb);
+		assertTrue(sb.toString().isEmpty());
+
+		labels.newInstruction(noOps);
+		labels.buildLabels();
+
+		sb.setLength(0);
+		labels.formatAddress(65535, sb);
+		assertEquals("0x000000000000ffff", sb.toString());
+		sb.setLength(0);
+		labels.formatOperands(noOps, sb);
+		assertTrue(sb.toString().isEmpty());
+	}
+}

--- a/src/test/java/org/adoptopenjdk/jitwatch/test/TestAssemblyUtil.java
+++ b/src/test/java/org/adoptopenjdk/jitwatch/test/TestAssemblyUtil.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyBlock;
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyInstruction;
+import org.adoptopenjdk.jitwatch.model.assembly.AssemblyLabels;
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyMethod;
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyUtil;
 import org.junit.Test;
@@ -127,7 +128,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007f4475904140: mov  0x8(%rsi),%r10d ;comment";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(), line);
 		
 		assertNotNull(instr);
 		
@@ -150,7 +151,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007f447590414d: data32 xchg %ax,%ax";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(),line);
 		
 		assertNotNull(instr);
 		
@@ -175,7 +176,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007f447590416e: hlt";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(), line);
 		
 		assertNotNull(instr);
 		
@@ -197,7 +198,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007fbbc41082e5: data32 data32 nopw 0x0(%rax,%rax,1)";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(), line);
 		
 		assertNotNull(instr);
 		
@@ -219,7 +220,7 @@ public class TestAssemblyUtil
 	{
 		String line = "0x00007f54f9bfd2f0: mov    %eax,-0x14000(%rsp)";
 		
-		AssemblyInstruction instr = AssemblyUtil.createInstruction(line);
+		AssemblyInstruction instr = AssemblyUtil.createInstruction(new AssemblyLabels(), line);
 		
 		assertNotNull(instr);
 		

--- a/src/test/java/org/adoptopenjdk/jitwatch/test/TestFindOptimizedVirtualCall.java
+++ b/src/test/java/org/adoptopenjdk/jitwatch/test/TestFindOptimizedVirtualCall.java
@@ -23,6 +23,7 @@ import org.adoptopenjdk.jitwatch.model.JITDataModel;
 import org.adoptopenjdk.jitwatch.model.MemberSignatureParts;
 import org.adoptopenjdk.jitwatch.model.MetaClass;
 import org.adoptopenjdk.jitwatch.model.assembly.AssemblyInstruction;
+import org.adoptopenjdk.jitwatch.model.assembly.AssemblyLabels;
 import org.adoptopenjdk.jitwatch.model.bytecode.BytecodeInstruction;
 import org.adoptopenjdk.jitwatch.model.bytecode.ClassBC;
 import org.adoptopenjdk.jitwatch.model.bytecode.MemberBytecode;
@@ -45,7 +46,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = S_EMPTY;
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -74,7 +75,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = null;
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -103,7 +104,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = "; Every day sends future a past.";
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -132,7 +133,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = "; - FooClass::fooMethod@1 (line 42)";
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -160,7 +161,7 @@ public class TestFindOptimizedVirtualCall
 		operands.add("%rax");
 		String firstComment = C_SEMICOLON + S_OPTIMIZED_VIRTUAL_CALL;
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, firstComment, new AssemblyLabels());
 
 		assertFalse(ins.isOptimizedVCall());
 
@@ -189,7 +190,7 @@ public class TestFindOptimizedVirtualCall
 
 		String comment0 = " ; OopMap{rbp=Oop off=940}";
 
-		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, comment0);
+		AssemblyInstruction ins = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, comment0, new AssemblyLabels());
 		ins.addCommentLine(";*invokevirtual toString");
 		ins.addCommentLine(callSiteComment);
 		ins.addCommentLine("; " + S_OPTIMIZED_VIRTUAL_CALL);
@@ -275,7 +276,7 @@ public class TestFindOptimizedVirtualCall
 				.getOptimizedVirtualCallSiteOrNull());
 	}
 
-	private static final int sourceLine = 282; // update if call to test2() changes line!
+	private static final int sourceLine = 283; // update if call to test2() changes line!
 
 	public void test1()
 	{
@@ -310,7 +311,7 @@ public class TestFindOptimizedVirtualCall
 		String comment2 = "; - " + fqClassName + "::" + callerMethod + "@" + vCallBCI + " (line " + sourceLine + ")";
 		String comment3 = ";  " + JITWatchConstants.S_OPTIMIZED_VIRTUAL_CALL;
 
-		AssemblyInstruction instruction = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, comment0);
+		AssemblyInstruction instruction = new AssemblyInstruction(annotation, address, modifier, mnemonic, operands, comment0, new AssemblyLabels());
 		instruction.addCommentLine(comment1);
 		instruction.addCommentLine(comment2);
 		instruction.addCommentLine(comment3);


### PR DESCRIPTION
Identify jump instructions that target instructions within a method.
Display the operand and the target address using a generated label. This
makes it easier to follow local control flow.