### PR TITLE
Fix suggestions NullPointerException

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/suggestion/AttributeSuggestionWalker.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/suggestion/AttributeSuggestionWalker.java
@@ -207,7 +207,9 @@ public class AttributeSuggestionWalker extends AbstractSuggestionVisitable imple
 			{
 				String callerID = attrs.get(ATTR_METHOD);
 				IMetaMember nestedCaller = ParseUtil.lookupMember(callerID, parseDictionary, model);
-				processParseTag(child, nestedCaller, parseDictionary);
+				if (nestedCaller != null) {
+					processParseTag(child, nestedCaller, parseDictionary);
+				}
 			}
 
 			default:


### PR DESCRIPTION
This is the NullPointerException I was getting when trying to filter on suggestions

```
java.lang.NullPointerException
        at org.adoptopenjdk.jitwatch.ui.suggestion.SuggestStage.display(SuggestStage.java:106)
        at org.adoptopenjdk.jitwatch.ui.suggestion.SuggestStage.setFilter(SuggestStage.java:127)
        at org.adoptopenjdk.jitwatch.ui.suggestion.SuggestionPackageFilter$1.changed(SuggestionPackageFilter.java:40)
        at org.adoptopenjdk.jitwatch.ui.suggestion.SuggestionPackageFilter$1.changed(SuggestionPackageFilter.java:34)
```
