### PR TITLE
Set up Bintray for released artifact publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ jitwatch.properties
 .idea
 jitwatch.i*
 build/
+.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
    id 'com.github.johnrengelman.shadow' version '1.2.2'  // fat jar
    id 'com.github.hierynomus.license' version '0.11.0'   // license checks
    id 'com.github.ben-manes.versions' version '0.11.3'   // version checks
-   id 'com.jfrog.bintray' version '1.3.1'
+   id 'com.jfrog.bintray' version '1.4'
    id 'maven-publish'
 }
 
@@ -222,7 +222,7 @@ bintray {
 
     version {
       name = project.version
-      released = Date.from(java.time.Instant.now())
+      released = new Date()
       vcsTag = 'v' + project.version
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -218,7 +218,7 @@ bintray {
     repo = 'maven'
     licenses = ['BSD 2-Clause']
     vcsUrl = 'https://github.com/AdoptOpenJDK/jitwatch'
-    name = 'net.java.adoptopenjdk:jitwatch'
+    name = "${project.group}:${project.name}"
 
     version {
       name = project.version

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ plugins {
    id 'com.github.johnrengelman.shadow' version '1.2.2'  // fat jar
    id 'com.github.hierynomus.license' version '0.11.0'   // license checks
    id 'com.github.ben-manes.versions' version '0.11.3'   // version checks
+   id 'com.jfrog.bintray' version '1.3.1'
+   id 'maven-publish'
 }
 
 // maven coordinates
@@ -174,10 +176,56 @@ idea {
     }
 }
 
+task sourceJar(type: Jar, dependsOn: classes) {
+  from sourceSets.main.allJava
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  from javadoc.destinationDir
+}
+
+publishing {
+  publications {
+    bintray(MavenPublication) {
+      from components.java
+      groupId project.group
+      artifactId project.name
+      version project.version
+
+      artifact sourceJar {
+        classifier 'sources'
+      }
+
+      artifact javadocJar {
+        classifier 'javadoc'
+      }
+    }
+  }
+}
+
 shadowJar {
     if (jdk != 'jdk9') {
         from project.files(toolsLocation)
     }
+}
+
+bintray {
+  user = rootProject.hasProperty('bintrayUser') ? rootProject.property('bintrayUser') : 'FIXME'
+  key = rootProject.hasProperty('bintrayApiKey') ? rootProject.property('bintrayApiKey') : 'FIXME'
+  publications = ['bintray']
+
+  pkg {
+    repo = 'maven'
+    licenses = ['BSD 2-Clause']
+    vcsUrl = 'https://github.com/AdoptOpenJDK/jitwatch'
+    name = 'net.java.adoptopenjdk:jitwatch'
+
+    version {
+      name = project.version
+      released = Date.from(java.time.Instant.now())
+      vcsTag = 'v' + project.version
+    }
+  }
 }
 
 task makeDemoLogFile(type: JavaExec) {

--- a/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyLabels.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyLabels.java
@@ -22,7 +22,7 @@ import org.adoptopenjdk.jitwatch.util.StringUtil;
  * Calculate symbolic names for method-local addresses.
  * 
  * <p>
- * Operates in two modes. During parsing, {@link #newInstruction()} accumulates
+ * Operates in two modes. During parsing, {@link #newInstruction(AssemblyInstruction)} accumulates
  * addresses used by instructions. After all the instructions have been parsed,
  * {@link #buildLabels()} builds an index of addresses of all known instructions
  * to label numbers, and {@link #formatAddress} and {@link #formatOperands}


### PR DESCRIPTION
Bintray is the thing behind jcenter (which is the artifact repo you already use). You can choose to sync your files into Maven Central as well for people who are unwilling/unable to use jcenter. (Jcenter is a superset of Maven Central's content, and also has fast CDNs, and a better UI and all that good stuff).

This is a basic setup of Bintray for releasing artifacts. I wasn't sure what artifacts you'd want to include so I just went with the default (jar, source jar, javadoc jar).

I also wasn't sure what naming convention you'd like to use for the final artifact. adoptopenjdk.org isn't actually a domain (it's adoptopenjdk.java.net), so you may wish to change your `group` to that to follow the 'reverse domain' convention.

To use this, you'll need to do the following:
- Sign up for https://bintray.com/. If you want to have this package (jitwatch) live under, say, 'chrisnewland', then you could use the 'maven' repo that they give you by default. If you want it to live organizationally under something like 'adoptopenjdk' then you could create a [Bintray organization](https://bintray.com/docs/usermanual/interacting/interacting_bintrayorganizations.html). This will change the url used to see the Bintray package. For instance, I do not bother with the organization thing for my own packages, so `marshallpierce` is in the URL of this package: https://bintray.com/marshallpierce/maven/org.mpierce.metrics.reservoir%3Ahdrhistogram-metrics-reservoir/view
- Add `bintrayUser` and `bintrayApiKey` to your `~/.gradle/gradle.properties` with values found in the [API key section of your profile](https://bintray.com/profile/edit).
- Set `version` to be a non-snapshot version (e.g. '1.0.0') -- bintray is only for released versions
- Run `./gradlew bintrayUpload`. This should auto-create the 'package' in the Bintray UI for you. You can go and add more details to it, but it should already have the license and URL filled out because that's in the `build.gradle` config. You'll see that it created a '1.0.0' version, and that it's asking you to take a look at the files uploaded and either publish them (so everyone can see) or discard them. If you don't do anything for 6 hours, it will auto-discard.

If you want to set up Maven Central syncing, see http://blog.bintray.com/2014/02/11/bintray-as-pain-free-gateway-to-maven-central/ and https://bintray.com/docs/usermanual/uploads/uploads_syncingartifactswithmavencentral.html.

I also drive-by-fixed a little javadoc thing and the inclusion of .gradle in .gitignore.