### PR TITLE
Enhance Maven Build and Prepare For Maven Central Deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,40 @@
                 <javafx.version>9</javafx.version>
             </properties>
         </profile>
+        
+   <!--============================ Deploy to Sonatype Staging Repo ================================ -->
+        <profile>
+            <id>deploy-to-sonatype-oss</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 	</profiles>
 
     <dependencyManagement>
@@ -231,6 +265,11 @@
                     <version>2.17</version>
                 </plugin>
                 <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-gpg-plugin</artifactId>
+                      <version>1.4</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.5.1</version>
@@ -249,13 +288,34 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.1</version>
+                    <configuration>
+                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <links>
+                            <link>http://docs.oracle.com/javase/8/docs/api/</link>
+                        </links>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5</version>
+                    <configuration>
+                        <mavenExecutorId>forked-path</mavenExecutorId>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <arguments>-Pdeploy-to-sonatype-oss</arguments>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -370,7 +430,19 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>            
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>      
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <name>jitwatch</name>
     <description>Visualisation of JIT behaviour</description>
-    <url>https://github.com/chriswhocodes/jitwatch</url>
+    <url>https://github.com/AdoptOpenJDK/jitwatch</url>
     <inceptionYear>2013</inceptionYear>
 
     <prerequisites>
@@ -520,7 +520,7 @@
 
     <scm>
         <developerConnection>scm:git:git@github.com:AdoptOpenJDK/jitwatch.git</developerConnection>
-        <url>https://github.com/AdoptOpenJDK/jitwatch</url>
+        <url>${project.url}</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.1.2</logback.version>
+        <main.class>org.adoptopenjdk.jitwatch.launch.LaunchUI</main.class>
     </properties>
 
     <profiles>
@@ -242,7 +243,7 @@
                     <configuration>
                         <archive>
                             <manifest>
-                                <mainClass>org.adoptopenjdk.jitwatch.launch.LaunchUI</mainClass>
+                                <mainClass>${main.class}</mainClass>
                             </manifest>
                         </archive>
                     </configuration>
@@ -381,7 +382,7 @@
                             <goal>java</goal>
                         </goals>
                         <configuration>
-                            <mainClass>org.adoptopenjdk.jitwatch.launch.LaunchUI</mainClass>
+                            <mainClass>${main.class}</mainClass>
                             <cleanupDaemonThreads>false</cleanupDaemonThreads>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -404,5 +404,18 @@
         <url>${project.url}</url>
         <tag>HEAD</tag>
     </scm>
+    
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,6 @@
 
     <groupId>org.adoptopenjdk.jitwatch</groupId>
     <artifactId>jitwatch</artifactId>
-    <packaging>jar</packaging>
     <version>1.0.0-SNAPSHOT</version>
 
     <name>jitwatch</name>
@@ -113,8 +112,6 @@
             </properties>
         </profile>
 	</profiles>
-
-   <!--========================================= Common dependencies across JDKs ============================================== -->
 
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>jitwatch</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
-    <name>jitwatch</name>
+    <name>JITWatch</name>
     <description>Visualisation of JIT behaviour</description>
     <url>https://github.com/AdoptOpenJDK/jitwatch</url>
     <inceptionYear>2013</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,7 @@
     </build>
 
     <scm>
+        <connection>scm:git:https://github.com/AdoptOpenJDK/jitwatch.git</connection>
         <developerConnection>scm:git:git@github.com:AdoptOpenJDK/jitwatch.git</developerConnection>
         <url>${project.url}</url>
         <tag>HEAD</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -81,78 +81,6 @@
                 <!-- Actually 2.2.x depending on what Java 7 you have -->
                 <javafx.version>2.2</javafx.version>
             </properties>
-            
-            <build>            
-            	<plugins>            
-                	<plugin>
-                    	<groupId>org.codehaus.mojo</groupId>
-                    	<artifactId>exec-maven-plugin</artifactId>
-                    	<version>1.3</version>
-                    	<executions>
-                        	<execution>
-                            	<goals>
-	                                <goal>java</goal>
-                            	</goals>
-                        	</execution>
-                    	</executions>
-                    	<configuration>
-	                        <includeProjectDependencies>true</includeProjectDependencies>
-                        	<includePluginDependencies>true</includePluginDependencies>
-                        	<mainClass>org.adoptopenjdk.jitwatch.launch.LaunchUI</mainClass>
-	                		<cleanupDaemonThreads>false</cleanupDaemonThreads>
-                        	<additionalClasspathElements>
-                            	<additionalClasspathElement>src/main/resources</additionalClasspathElement>
-                        	</additionalClasspathElements>
-                    	</configuration>                
-						<dependencies>
-    						<dependency>
-        						<groupId>com.oracle</groupId>
-            					<artifactId>javafx</artifactId>
-            					<version>${javafx.version}</version>
-            					<systemPath>${jfxrt.jar}</systemPath>
-            					<scope>system</scope>
-        					</dependency>
-        					<dependency>
-        						<groupId>com.oracle</groupId>
-            					<artifactId>tools.jar</artifactId>
-            					<version>${jdk.version}</version>
-            					<systemPath>${tools.jar}</systemPath>
-            					<scope>system</scope>
-       						</dependency>
-						</dependencies>
-	                </plugin>
-				</plugins>            
-			</build>
-                                
-		<dependencyManagement>
-        	<dependencies>
-            	<dependency>
-	                <groupId>com.oracle</groupId>
-                	<artifactId>javafx</artifactId>
-                	<version>${javafx.version}</version>
-            	</dependency>
-            	<dependency>
-	                <groupId>com.oracle</groupId>
-                	<artifactId>tools.jar</artifactId>
-                	<version>${jdk.version}</version>
-            	</dependency>
-        	</dependencies>
-		</dependencyManagement>                                
-                                
-			<dependencies>
-        		<dependency>
-            		<groupId>com.oracle</groupId>
-            		<artifactId>tools.jar</artifactId>
-            		<systemPath>${tools.jar}</systemPath>
-            		<scope>system</scope>
-        		</dependency>
-				<dependency>
-            		<groupId>com.oracle</groupId>
-            		<artifactId>javafx</artifactId>
-            		<systemPath>${jfxrt.jar}</systemPath>
-            		<scope>system</scope>
-        		</dependency>
-			</dependencies>
         </profile>
         
     <!--========================================= JDK 8 ============================================== -->
@@ -169,119 +97,20 @@
                 <!-- Generic version number as Oracle doesn't release separate jars -->
                 <javafx.version>8</javafx.version>
             </properties>
-            <build>
-			<plugins>            
-				<plugin>
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>exec-maven-plugin</artifactId>
-					<version>1.3</version>
-					<executions>
-						<execution>
-                        	<goals>
-                                <goal>java</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <includeProjectDependencies>true</includeProjectDependencies>
-                        <includePluginDependencies>true</includePluginDependencies>
-                        <mainClass>org.adoptopenjdk.jitwatch.launch.LaunchUI</mainClass>
-	                	<cleanupDaemonThreads>false</cleanupDaemonThreads>
-                       	<additionalClasspathElements>
-							<additionalClasspathElement>src/main/resources</additionalClasspathElement>
-						</additionalClasspathElements>
-                   	</configuration>
-					<dependencies>
-    					<dependency>
-        					<groupId>com.oracle</groupId>
-            				<artifactId>javafx</artifactId>
-            				<version>${javafx.version}</version>
-            				<systemPath>${jfxrt.jar}</systemPath>
-            				<scope>system</scope>
-        				</dependency>
-        				<dependency>
-        					<groupId>com.oracle</groupId>
-            				<artifactId>tools.jar</artifactId>
-            				<version>${jdk.version}</version>
-            				<systemPath>${tools.jar}</systemPath>
-            				<scope>system</scope>
-       					</dependency>
-					</dependencies>
-                </plugin>
-			</plugins>            
-		</build>
-            
-		<dependencyManagement>
-        	<dependencies>
-            	<dependency>
-	                <groupId>com.oracle</groupId>
-                	<artifactId>javafx</artifactId>
-                	<version>${javafx.version}</version>
-            	</dependency>
-            	<dependency>
-	                <groupId>com.oracle</groupId>
-                	<artifactId>tools.jar</artifactId>
-                	<version>${jdk.version}</version>
-            	</dependency>
-        	</dependencies>
-		</dependencyManagement>
-            
-			<dependencies>
-        		<dependency>
-            		<groupId>com.oracle</groupId>
-            		<artifactId>tools.jar</artifactId>
-            		<systemPath>${tools.jar}</systemPath>
-            		<scope>system</scope>
-        		</dependency>
-				<dependency>
-            		<groupId>com.oracle</groupId>
-            		<artifactId>javafx</artifactId>
-            		<systemPath>${jfxrt.jar}</systemPath>
-            		<scope>system</scope>
-        		</dependency>
-			</dependencies>
         </profile>
         
    <!--========================================= JDK9 ============================================== -->
-	<profile>    
-        	<id>jdk9</id>
-		<activation>
-			<jdk>1.9</jdk>
-		</activation>
-		<properties>
-                	<jdk.version>1.9</jdk.version>
-			<!-- Generic version number as Oracle doesn't release separate jars -->
-			<javafx.version>9</javafx.version>
-		</properties>
-		<build>
-			<plugins>            
-				<plugin>
-		                    	<groupId>org.codehaus.mojo</groupId>
-		                    	<artifactId>exec-maven-plugin</artifactId>
-		                    	<version>1.3</version>
-		                    	<executions>
-			                        <execution>
-			    	                        <goals>
-			                                	<goal>java</goal>
-			                            	</goals>
-		                        	</execution>
-                		    	</executions>
-		                    	<configuration>
-						<arguments>
-								<argument>-Djava.library.path=${java.home}/lib</argument>
-       						</arguments>
-		                        	<includeProjectDependencies>true</includeProjectDependencies>
-		                        	<includePluginDependencies>true</includePluginDependencies>
-		                        	<mainClass>org.adoptopenjdk.jitwatch.launch.LaunchUI</mainClass>
-	        	        		<cleanupDaemonThreads>false</cleanupDaemonThreads>
-                        			<additionalClasspathElements>
-			                            	<additionalClasspathElement>src/main/resources</additionalClasspathElement>
-		                        	</additionalClasspathElements>
-		                    	</configuration>
-				</plugin>
-			</plugins>            
-		</build>           
-	</profile>
+    	<profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>1.9</jdk>
+            </activation>
+            <properties>
+                <jdk.version>1.9</jdk.version>
+                <!-- Generic version number as Oracle doesn't release separate jars -->
+                <javafx.version>9</javafx.version>
+            </properties>
+        </profile>
 	</profiles>
 
    <!--========================================= Common dependencies across JDKs ============================================== -->
@@ -303,6 +132,23 @@
                 <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
             </dependency>
+            
+            <!-- System dependencies -->
+            <dependency>
+                <groupId>com.oracle</groupId>
+                <artifactId>tools</artifactId>
+                <version>${jdk.version}</version>
+                <systemPath>${tools.jar}</systemPath>
+                <scope>system</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle</groupId>
+                <artifactId>javafx</artifactId>
+                <version>${javafx.version}</version>
+                <systemPath>${jfxrt.jar}</systemPath>
+                <scope>system</scope>
+            </dependency>
+            
             <!-- Test dependencies -->
             <dependency>
                 <groupId>junit</groupId>
@@ -325,6 +171,14 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle</groupId>
+            <artifactId>tools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle</groupId>
+            <artifactId>javafx</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -384,10 +238,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>2.6</version>
                     <configuration>
                         <archive>
-                            <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
+                            <manifest>
+                                <mainClass>org.adoptopenjdk.jitwatch.launch.LaunchUI</mainClass>
+                            </manifest>
                         </archive>
                     </configuration>
                 </plugin>
@@ -410,6 +266,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -509,6 +370,24 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>            
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.adoptopenjdk.jitwatch.launch.LaunchUI</mainClass>
+                            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>          
 
         <!-- TODO Correct license if license plugin someday supports simplified BSD -->
         <!-- <plugins> <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>license-maven-plugin</artifactId> 

--- a/pom.xml
+++ b/pom.xml
@@ -289,11 +289,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.11</version>
-            </dependency>           
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
@@ -308,15 +303,17 @@
                 <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
             </dependency>
+            <!-- Test dependencies -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.11</version>
+                <scope>test</scope>
+            </dependency>           
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -328,6 +325,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
     <licenses>
         <license>
             <name>Simplified BSD License</name>
+            <url>http://opensource.org/licenses/BSD-3-Clause</url>
+            <distribution>repo</distribution>
             <comments>Simplified BSD License</comments>
         </license>
     </licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,15 @@
                 <!-- Actually 2.2.x depending on what Java 7 you have -->
                 <javafx.version>2.2</javafx.version>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>com.oracle</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>${jdk.version}</version>
+                    <systemPath>${tools.jar}</systemPath>
+                    <scope>system</scope>
+                </dependency>
+            </dependencies>
         </profile>
         
     <!--========================================= JDK 8 ============================================== -->
@@ -99,6 +108,15 @@
                 <!-- Generic version number as Oracle doesn't release separate jars -->
                 <javafx.version>8</javafx.version>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>com.oracle</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>${jdk.version}</version>
+                    <systemPath>${tools.jar}</systemPath>
+                    <scope>system</scope>
+                </dependency>
+            </dependencies>
         </profile>
         
    <!--========================================= JDK9 ============================================== -->
@@ -108,6 +126,7 @@
                 <jdk>1.9</jdk>
             </activation>
             <properties>
+                <jfxrt.jar>${java.home}/lib/jfxrt.jar</jfxrt.jar>
                 <jdk.version>1.9</jdk.version>
                 <!-- Generic version number as Oracle doesn't release separate jars -->
                 <javafx.version>9</javafx.version>
@@ -170,13 +189,6 @@
             <!-- System dependencies -->
             <dependency>
                 <groupId>com.oracle</groupId>
-                <artifactId>tools</artifactId>
-                <version>${jdk.version}</version>
-                <systemPath>${tools.jar}</systemPath>
-                <scope>system</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.oracle</groupId>
                 <artifactId>javafx</artifactId>
                 <version>${javafx.version}</version>
                 <systemPath>${jfxrt.jar}</systemPath>
@@ -205,10 +217,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle</groupId>
-            <artifactId>tools</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle</groupId>
@@ -246,7 +254,7 @@
                         <source>${jdk.version}</source>
                         <target>${jdk.version}</target>
                         <compilerArgument>-Xlint:unchecked</compilerArgument>
-        		<compilerArgument>-g:source,lines</compilerArgument>
+        		        <compilerArgument>-g:source,lines</compilerArgument>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
     <developers>
         <developer>
             <name>Chris Newland</name>
+            <url>http://www.chrisnewland.com</url>
+            <email>chris@chrisnewland.com</email>
             <timezone>GMT</timezone>
         </developer>
     </developers>

--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,7 @@
                         <configuration>
                             <mainClass>${main.class}</mainClass>
                             <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                            <classpathScope>compile</classpathScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-Main-Class: org.adoptopenjdk.jitwatch.launch.LaunchUI


### PR DESCRIPTION
This PR makes some cleanups and simplifications in the Maven build and enhances it to meet the [requirements for Maven Central deployment](http://central.sonatype.org/pages/requirements.html).

The main simplifications are:
- The JDK profiles do only define the paths to tools.jar (if available) and jfxrt.jar
- One global and simplified configuration of the exec-maven-plugin
- The `MANIFEST.MF` will now be generated during the build. The file in `src/main/resources/META-INF` is not necessary anymore.

Enhancements for Maven Central deployment:
- Add a `<distributionManagement>` section pointing to the Sonatype snapshot and staging repositories
- Complete the missing parts in the POM
- Create source and Javadoc JARs (Javadoc only during release build)
- Create PGP signatures during release build (PGP needs to be configured for that)

What still needs to be done for Maven Central deployment:
Basically, you need to get access to the Sonatype repositories and setup GPG. There is plenty of documentation for the Maven Central deployment. The main entry point is the [OSSRH Guide](http://central.sonatype.org/pages/ossrh-guide.html). The instructions for Maven can be found [here](http://central.sonatype.org/pages/apache-maven.html).
