### PR TITLE
Code Quality Improvements - @Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/histo/AbstractHistoVisitable.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/histo/AbstractHistoVisitable.java
@@ -24,6 +24,7 @@ public abstract class AbstractHistoVisitable extends AbstractJournalVisitable im
 		this.resolution = resolution;
 	}
 
+	@Override
 	public Histo buildHistogram()
 	{
 		histo = new Histo(resolution);
@@ -33,6 +34,7 @@ public abstract class AbstractHistoVisitable extends AbstractJournalVisitable im
 		return histo;
 	}
 
+	@Override
 	public void reset()
 	{
 	}

--- a/src/main/java/org/adoptopenjdk/jitwatch/model/AbstractMetaMember.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/AbstractMetaMember.java
@@ -256,6 +256,7 @@ public abstract class AbstractMetaMember implements IMetaMember, Comparable<IMet
 		return result;
 	}
 
+	@Override
 	public List<BytecodeInstruction> getInstructions()
 	{
 		List<BytecodeInstruction> result = null;

--- a/src/main/java/org/adoptopenjdk/jitwatch/model/IParseDictionary.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/IParseDictionary.java
@@ -19,5 +19,6 @@ public interface IParseDictionary
 
 	Tag getMethod(String id);
 	
+	@Override
 	String toString();
 }

--- a/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyBlock.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/assembly/AssemblyBlock.java
@@ -47,6 +47,7 @@ public class AssemblyBlock
 		return instructions;
 	}
 
+	@Override
 	public String toString()
 	{
 		return toString(0);

--- a/src/main/java/org/adoptopenjdk/jitwatch/model/bytecode/BytecodeAnnotations.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/bytecode/BytecodeAnnotations.java
@@ -62,6 +62,7 @@ public class BytecodeAnnotations
 		return annotationMap.size();
 	}
 
+	@Override
 	public String toString()
 	{
 		StringBuilder builder = new StringBuilder();

--- a/src/main/java/org/adoptopenjdk/jitwatch/model/bytecode/LineAnnotation.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/bytecode/LineAnnotation.java
@@ -28,6 +28,7 @@ public class LineAnnotation
 		return type;
 	}
 
+	@Override
 	public String toString()
 	{
 		StringBuilder builder = new StringBuilder();

--- a/src/main/java/org/adoptopenjdk/jitwatch/toplist/MemberScore.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/toplist/MemberScore.java
@@ -18,11 +18,13 @@ public class MemberScore implements ITopListScore
 		this.score = score;
 	}
 	
+	@Override
 	public IMetaMember getKey()
 	{
 		return member;
 	}
 
+	@Override
 	public long getScore()
 	{
 		return score;

--- a/src/main/java/org/adoptopenjdk/jitwatch/toplist/StringTopListScore.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/toplist/StringTopListScore.java
@@ -16,11 +16,13 @@ public class StringTopListScore implements ITopListScore
 		this.score = score;
 	}
 	
+	@Override
 	public String getKey()
 	{
 		return key;
 	}
 
+	@Override
 	public long getScore()
 	{
 		return score;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1161 - "@Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1161.

Please let me know if you have any questions.

Christian