### PR TITLE
Modify HistoPlotter to use 1.7 API

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/jarscan/visualiser/HistoPlotter.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/jarscan/visualiser/HistoPlotter.java
@@ -1,6 +1,7 @@
 package org.adoptopenjdk.jitwatch.jarscan.visualiser;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class HistoPlotter extends Application
 
 			String inputPath = unnamedParameters.get(0);
 
-			lines = Files.readAllLines(Paths.get(inputPath));
+			lines = Files.readAllLines(Paths.get(inputPath),StandardCharsets.UTF_8);
 		}
 		catch (IOException e)
 		{


### PR DESCRIPTION
The Files.readAllLines(Path) method is specific to Java 1.8, and just delegates to Files.readAllLines(Path,Charset). By using that instead it will be possible to avoid compile-time errors when compiling against Java 1.7.

Fixes #201