### PR TITLE
Add public method to add allowed package prefixes

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/jarscan/JarScan.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/jarscan/JarScan.java
@@ -91,6 +91,11 @@ public class JarScan
 		}
 	}
 
+	public void addAllowedPackagePrefix(String prefix)
+	{
+		allowedPackagePrefixes.add(prefix);
+	}
+
 	private boolean isAllowedPackage(String fqClassName)
 	{
 		boolean allowed = false;
@@ -375,8 +380,7 @@ public class JarScan
 			for (String prefix : prefixes)
 			{
 				prefix = prefix.replace(S_ASTERISK, S_EMPTY);
-
-				scanner.allowedPackagePrefixes.add(prefix);
+				scanner.addAllowedPackagePrefix(prefix);
 			}
 		}
 


### PR DESCRIPTION
I am working on a new version of the [jitwatch-jarscan-maven-plugin](https://github.com/ferstl/jitwatch-jarscan-maven-plugin) and would like to integrate the feature for allowing packages. In order to do that  a **public** method to add allowed packages would be very convenient.
