### PR TITLE
Allow to customize generation of bytecode annotation text

### DIFF
--- a/src/main/java/org/adoptopenjdk/jitwatch/model/bytecode/BytecodeAnnotationBuilder.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/bytecode/BytecodeAnnotationBuilder.java
@@ -358,8 +358,9 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 
 		int currentBytecode = -1;
 
-		Map<String, String> methodAttrs = new HashMap<>();
+		Map<String, Map<String, String>> methodAttrs = new HashMap<>();
 		Map<String, String> callAttrs = new HashMap<>();
+		Map<String, String> lastMethodAttrs = new HashMap<>();
 
 		String currentMethodID = parseTag.getAttribute(ATTR_METHOD);
 
@@ -406,14 +407,27 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 				callAttrs.clear();
 				callAttrs.putAll(tagAttrs);
 
+				lastMethodAttrs.clear();
+				String calleeId = tagAttrs.get("method");
+				if (calleeId != null)
+				{
+					Map<String, String> calleeAttrs = methodAttrs.get(calleeId);
+					if (calleeAttrs != null)
+					{
+						lastMethodAttrs.putAll(calleeAttrs);
+					}
+				}
+
 				break;
 			}
 
 			case TAG_METHOD:
 			{
-				methodAttrs.clear();
-				methodAttrs.putAll(tagAttrs);
-
+				String methodId = tagAttrs.get("id");
+				if (methodId != null)
+				{
+					methodAttrs.put(methodId, tagAttrs);
+				}
 				break;
 			}
 
@@ -426,7 +440,7 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 				}
 
 				String reason = tagAttrs.get(ATTR_REASON);
-				String annotationText = buildInlineAnnotation(parseDictionary, methodAttrs, callAttrs, reason, true);
+				String annotationText = buildInlineAnnotation(parseDictionary, lastMethodAttrs, callAttrs, reason, true);
 
 				bcAnnotations.addAnnotation(currentBytecode, new LineAnnotation(annotationText, BCAnnotationType.INLINE_SUCCESS));
 
@@ -443,7 +457,7 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 				}
 
 				String reason = tagAttrs.get(ATTR_REASON);
-				String annotationText = buildInlineAnnotation(parseDictionary, methodAttrs, callAttrs, reason, false);
+				String annotationText = buildInlineAnnotation(parseDictionary, lastMethodAttrs, callAttrs, reason, false);
 
 				bcAnnotations.addAnnotation(currentBytecode, new LineAnnotation(annotationText, BCAnnotationType.INLINE_FAIL));
 

--- a/src/main/java/org/adoptopenjdk/jitwatch/model/bytecode/BytecodeAnnotationBuilder.java
+++ b/src/main/java/org/adoptopenjdk/jitwatch/model/bytecode/BytecodeAnnotationBuilder.java
@@ -213,10 +213,6 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 
 						if (instr != null)
 						{
-							StringBuilder builder = new StringBuilder();
-							builder.append("Object does not escape method.\n");
-							builder.append("Heap allocation has been eliminated.\n");
-
 							String typeID = tag.getAttribute(ATTR_TYPE);
 
 							String typeOrKlassName = null;
@@ -225,16 +221,14 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 							{
 								typeOrKlassName = ParseUtil.lookupType(typeID, parseDictionary);
 
-								if (typeOrKlassName != null)
-								{
-									builder.append("Eliminated allocation was of type ").append(typeOrKlassName);
-								}
 							}
+
+							String annotation = buildEliminatedAllocationAnnotation(typeOrKlassName);
 
 							if (instr.getOpcode() == Opcode.NEW)
 							{
 								bcAnnotations.addAnnotation(bciValue,
-										new LineAnnotation(builder.toString(), BCAnnotationType.ELIMINATED_ALLOCATION));
+										new LineAnnotation(annotation, BCAnnotationType.ELIMINATED_ALLOCATION));
 
 								instr.setEliminated(true);
 							}
@@ -432,8 +426,7 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 				}
 
 				String reason = tagAttrs.get(ATTR_REASON);
-				String annotationText = TooltipUtil.buildInlineAnnotationText(true, reason, callAttrs, methodAttrs,
-						parseDictionary);
+				String annotationText = buildInlineAnnotation(parseDictionary, methodAttrs, callAttrs, reason, true);
 
 				bcAnnotations.addAnnotation(currentBytecode, new LineAnnotation(annotationText, BCAnnotationType.INLINE_SUCCESS));
 
@@ -450,8 +443,7 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 				}
 
 				String reason = tagAttrs.get(ATTR_REASON);
-				String annotationText = TooltipUtil.buildInlineAnnotationText(false, reason, callAttrs, methodAttrs,
-						parseDictionary);
+				String annotationText = buildInlineAnnotation(parseDictionary, methodAttrs, callAttrs, reason, false);
 
 				bcAnnotations.addAnnotation(currentBytecode, new LineAnnotation(annotationText, BCAnnotationType.INLINE_FAIL));
 
@@ -530,7 +522,27 @@ public class BytecodeAnnotationBuilder extends AbstractJournalVisitable
 		}
 	}
 
-	private String buildBranchAnnotation(Map<String, String> tagAttrs)
+	protected String buildInlineAnnotation(IParseDictionary parseDictionary, Map<String, String> methodAttrs,
+																				 Map<String, String> callAttrs, String reason, boolean inlined)
+	{
+		return TooltipUtil.buildInlineAnnotationText(inlined, reason, callAttrs, methodAttrs,
+				parseDictionary);
+	}
+
+	protected String buildEliminatedAllocationAnnotation(String typeOrKlassName)
+	{
+		StringBuilder builder = new StringBuilder();
+		builder.append("Object does not escape method.\n");
+		builder.append("Heap allocation has been eliminated.\n");
+
+		if (typeOrKlassName != null)
+		{
+			builder.append("Eliminated allocation was of type ").append(typeOrKlassName);
+		}
+		return builder.toString();
+	}
+
+	protected String buildBranchAnnotation(Map<String, String> tagAttrs)
 	{
 		String count = tagAttrs.get(ATTR_BRANCH_COUNT);
 		String taken = tagAttrs.get(ATTR_BRANCH_TAKEN);


### PR DESCRIPTION
Context: I'm building a JITWatch integration plugin for IntelliJ IDEA. The text generated by the current implementation isn't optimal for IDE representation (one reason is that IntelliJ IDEA does not render line breaks in annotation text), so I'd like to customize the text while keeping all of the surrounding logic.