### PR TITLE
Draw Code Cache Usage line when there are "sweeper" tags

### DIFF
--- a/ui/src/main/java/org/adoptopenjdk/jitwatch/ui/graphing/CodeCacheStage.java
+++ b/ui/src/main/java/org/adoptopenjdk/jitwatch/ui/graphing/CodeCacheStage.java
@@ -5,24 +5,20 @@
  */
 package org.adoptopenjdk.jitwatch.ui.graphing;
 
-import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.ATTR_FREE_CODE_CACHE;
-import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_CODE_CACHE;
-import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_CODE_CACHE_FULL;
-import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_SWEEPER;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.stage.StageStyle;
+import org.adoptopenjdk.jitwatch.model.Tag;
+import org.adoptopenjdk.jitwatch.ui.JITWatchUI;
+import org.adoptopenjdk.jitwatch.util.UserInterfaceUtil;
 
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
-import org.adoptopenjdk.jitwatch.model.Tag;
-import org.adoptopenjdk.jitwatch.ui.JITWatchUI;
-import org.adoptopenjdk.jitwatch.util.UserInterfaceUtil;
-
-import javafx.scene.Scene;
-import javafx.scene.layout.StackPane;
-import javafx.scene.paint.Color;
-import javafx.stage.StageStyle;
+import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.*;
 
 public class CodeCacheStage extends AbstractGraphStage
 {
@@ -122,19 +118,11 @@ public class CodeCacheStage extends AbstractGraphStage
 				switch (ccTag.getName())
 				{
 				case TAG_CODE_CACHE:
-					long freeCodeCache = getFreeCodeCacheFromTag(ccTag);
-
-					y = graphGapTop + normaliseY(freeCodeCache);
-
-					gc.setFill(colourLine);
-					gc.setStroke(colourLine);
-					gc.setLineWidth(lineWidth);
-
-					gc.strokeLine(fix(lastCX), fix(lastCY), fix(x), fix(y));
-
+					y = addToGraph(lastCX, lastCY, colourLine, lineWidth, ccTag, x);
 					break;
 
 				case TAG_SWEEPER:
+					y = addToGraph(lastCX, lastCY, colourLine, lineWidth, ccTag, x);
 					showLabel("Sweep", Color.WHITE, x, y);
 					break;
 					
@@ -153,6 +141,20 @@ public class CodeCacheStage extends AbstractGraphStage
 		{
 			gc.fillText("No code cache information in log", fix(10), fix(10));
 		}
+	}
+
+	private double addToGraph(double lastCX, double lastCY, Color colourLine, double lineWidth, Tag ccTag, double x) {
+		double y;
+		long freeCodeCache = getFreeCodeCacheFromTag(ccTag);
+
+		y = graphGapTop + normaliseY(freeCodeCache);
+
+		gc.setFill(colourLine);
+		gc.setStroke(colourLine);
+		gc.setLineWidth(lineWidth);
+
+		gc.strokeLine(fix(lastCX), fix(lastCY), fix(x), fix(y));
+		return y;
 	}
 
 	private void showLabel(String text, Color background, double x, double y)


### PR DESCRIPTION
Hello,

while using the following options with a JVM 1.8_45 `-XX:+UnlockDiagnosticVMOptions -XX:+TraceClassLoading -XX:+LogCompilation ` I faced an issue with the Code Cache graph.

## Before
The line was not drawn.

![before](https://cloud.githubusercontent.com/assets/7994688/16041603/9bf9237e-3236-11e6-8499-bb3ebcc2ef18.png)

## After 
As the sweeper tag contains the `free_code_cache` information, I used it to draw the line.

![after](https://cloud.githubusercontent.com/assets/7994688/16041604/9bfc5f80-3236-11e6-95e2-9842b2e3bb1e.png)

## Changes:

> - Extract method to draw line between the last point and the new one
> - Draw line also for TAG_SWEEPER

I didn't find any test. I might add tests if you have a way to test visual parts.
Moreover the Eclipse setting file is not available anymore (link from the wiki), so Sorry, my IntelliJ re-arranged the imports :/
