### PR TITLE
JITWatch could be launched on Java SE 7(version smaller than 7u101)

### DIFF
--- a/ui/src/main/java/org/adoptopenjdk/jitwatch/launch/LaunchUI.java
+++ b/ui/src/main/java/org/adoptopenjdk/jitwatch/launch/LaunchUI.java
@@ -6,6 +6,8 @@
 package org.adoptopenjdk.jitwatch.launch;
 
 import org.adoptopenjdk.jitwatch.ui.JITWatchUI;
+import java.lang.reflect.Field;
+import java.util.HashMap;
 
 public final class LaunchUI
 {
@@ -15,6 +17,23 @@ public final class LaunchUI
 
 	public static void main(String[] args)
 	{
+		try {
+            final Class<?> macFontFinderClass = Class.forName("com.sun.t2k.MacFontFinder");
+            final Field psNameToPathMap = macFontFinderClass.getDeclaredField("psNameToPathMap");
+            psNameToPathMap.setAccessible(true);
+            if (psNameToPathMap.get(null) == null) {
+                psNameToPathMap.set(
+                    null, new HashMap<String, String>());
+            }
+            final Field allAvailableFontFamilies = macFontFinderClass.getDeclaredField("allAvailableFontFamilies");
+            allAvailableFontFamilies.setAccessible(true);
+            if (allAvailableFontFamilies.get(null) == null) {
+                allAvailableFontFamilies.set(
+                    null, new String[] {});
+            }
+        } catch (final Exception e) {
+            // ignore
+        }
 		new JITWatchUI(args);
 	}
 }

--- a/ui/src/main/java/org/adoptopenjdk/jitwatch/launch/LaunchUI.java
+++ b/ui/src/main/java/org/adoptopenjdk/jitwatch/launch/LaunchUI.java
@@ -17,23 +17,41 @@ public final class LaunchUI
 
 	public static void main(String[] args)
 	{
-		try {
-            final Class<?> macFontFinderClass = Class.forName("com.sun.t2k.MacFontFinder");
-            final Field psNameToPathMap = macFontFinderClass.getDeclaredField("psNameToPathMap");
-            psNameToPathMap.setAccessible(true);
-            if (psNameToPathMap.get(null) == null) {
-                psNameToPathMap.set(
-                    null, new HashMap<String, String>());
-            }
-            final Field allAvailableFontFamilies = macFontFinderClass.getDeclaredField("allAvailableFontFamilies");
-            allAvailableFontFamilies.setAccessible(true);
-            if (allAvailableFontFamilies.get(null) == null) {
-                allAvailableFontFamilies.set(
-                    null, new String[] {});
-            }
-        } catch (final Exception e) {
-            // ignore
-        }
+		if (isMac()) {
+			initMacFont();
+		}
 		new JITWatchUI(args);
+	}
+
+	private static boolean isMac()
+	{
+		String OS = System.getProperty("os.name").toLowerCase();
+		if (OS != null && OS.indexOf("mac") >= 0) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * to see: https://bugs.openjdk.java.net/browse/JDK-8143907
+	 */
+	private static void initMacFont()
+	{
+		try {
+			final Class<?> macFontFinderClass = Class.forName("com.sun.t2k.MacFontFinder");
+			final Field psNameToPathMap = macFontFinderClass.getDeclaredField("psNameToPathMap");
+			psNameToPathMap.setAccessible(true);
+			if (psNameToPathMap.get(null) == null) {
+				psNameToPathMap.set(null, new HashMap<String, String>());
+			}
+			final Field allAvailableFontFamilies = macFontFinderClass.getDeclaredField("allAvailableFontFamilies");
+			allAvailableFontFamilies.setAccessible(true);
+			if (allAvailableFontFamilies.get(null) == null) {
+				allAvailableFontFamilies.set(null, new String[] {});
+			}
+		} catch (final Exception e) {
+			// ignore
+		}
 	}
 }


### PR DESCRIPTION
to see: https://bugs.openjdk.java.net/browse/JDK-8143907
This bug fixed in version 7u101, but my version is:
```
weagers-MBP:jitwatch weager$ java -version
java version "1.7.0_79"
Java(TM) SE Runtime Environment (build 1.7.0_79-b15)
Java HotSpot(TM) 64-Bit Server VM (build 24.79-b02, mixed mode)
```

When I run this command `mvn clean compile test exec:java`, an error is thrown:

```
Caused by: java.lang.NullPointerException
	at com.sun.t2k.MacFontFinder.initPSFontNameToPathMap(MacFontFinder.java:339)
	at com.sun.t2k.MacFontFinder.getFontNamesOfFontFamily(MacFontFinder.java:390)
	at com.sun.t2k.T2KFontFactory.getFontResource(T2KFontFactory.java:233)
	at com.sun.t2k.LogicalFont.getSlot0Resource(LogicalFont.java:184)
	at com.sun.t2k.LogicalFont.getSlotResource(LogicalFont.java:228)
	at com.sun.t2k.CompositeStrike.getStrikeSlot(CompositeStrike.java:86)
	at com.sun.t2k.CompositeStrike.getMetrics(CompositeStrike.java:132)
	at com.sun.javafx.font.PrismFontUtils.getFontMetrics(PrismFontUtils.java:31)
	at com.sun.javafx.font.PrismFontLoader.getFontMetrics(PrismFontLoader.java:466)
	at javafx.scene.text.Text.<init>(Text.java:153)
	at com.sun.javafx.scene.control.skin.Utils.<clinit>(Utils.java:52)
	... 13 more

[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.5.0:java (default-cli) on project jitwatch-ui: An exception occured while executing the Java class. null: InvocationTargetException: Exception in Application start method: ExceptionInInitializerError: NullPointerException -> [Help 1]
```

Then I searched on Stackoverflow.com, I found that several guys had similar error, and someone gave a solution, then I used it in my pull request.

I tested this pull request in Java7 and Java8, it works well.