### PR TITLE
Use externally specified iterations count for sort demo function.

### DIFF
--- a/core/src/main/java/org/adoptopenjdk/jitwatch/demo/MakeHotSpotLog.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/demo/MakeHotSpotLog.java
@@ -40,7 +40,7 @@ public class MakeHotSpotLog
 		intrinsicTest(iterations);
 		intrinsicTestMin(iterations);
 		tooBigToInline(iterations);
-		testSort();
+		testSort(iterations);
 		testCallChain(iterations);
 		testOptimizedVCall(iterations);
 
@@ -249,13 +249,13 @@ public class MakeHotSpotLog
 		return result;
 	}
 
-	private void testSort()
+	private void testSort(long iterations)
 	{
 
 		long sum = 0;
 
 		// ensure sort is JIT compiled
-		for (int i = 0; i < 20000; i++)
+		for (int i = 0; i < iterations; i++)
 		{
 			Random random = new Random();
 


### PR DESCRIPTION
When tiered compilation is used, 20000 iterations only trigger a C1 compile, and escape analysis (which would otherwise eliminate the Random allocation) does not kick in.