### PR TITLE
Allow specifying javap path as parameter to BytecodeLoader.

### DIFF
--- a/core/src/main/java/org/adoptopenjdk/jitwatch/loader/BytecodeLoader.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/loader/BytecodeLoader.java
@@ -36,6 +36,7 @@ import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.S_NEWLINE;
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.S_SEMICOLON;
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.S_SLASH;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -103,6 +104,12 @@ public final class BytecodeLoader
 
 	public static ClassBC fetchBytecodeForClass(List<String> classLocations, String fqClassName, boolean cacheBytecode)
 	{
+		return fetchBytecodeForClass(classLocations, fqClassName, null, cacheBytecode);
+	}
+
+	public static ClassBC fetchBytecodeForClass(List<String> classLocations, String fqClassName, Path javapPath,
+																							boolean cacheBytecode)
+	{
 		if (DEBUG_LOGGING_BYTECODE)
 		{
 			logger.debug("fetchBytecodeForClass: {}", fqClassName);
@@ -112,7 +119,15 @@ public final class BytecodeLoader
 
 		try
 		{
-			JavapProcess javapProcess = new JavapProcess();
+			JavapProcess javapProcess;
+			if (javapPath != null)
+			{
+				javapProcess = new JavapProcess(javapPath);
+			}
+			else
+			{
+				javapProcess = new JavapProcess();
+			}
 
 			javapProcess.execute(classLocations, fqClassName);
 

--- a/core/src/main/java/org/adoptopenjdk/jitwatch/model/MetaClass.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/model/MetaClass.java
@@ -12,6 +12,7 @@ import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.DEBUG_LOGGING_SIG
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.S_DOT;
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.S_SLASH;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -98,6 +99,11 @@ public class MetaClass implements Comparable<MetaClass>
 
 	public ClassBC getClassBytecode(IReadOnlyJITDataModel model, List<String> classLocations)
 	{
+		return getClassBytecode(model, classLocations, null);
+	}
+
+	public ClassBC getClassBytecode(IReadOnlyJITDataModel model, List<String> classLocations, Path javapPath)
+	{
 		if (DEBUG_LOGGING_BYTECODE)
 		{
 			logger.debug("getClassBytecode for {} existing? {}", getName(), classBytecode != null);
@@ -105,7 +111,7 @@ public class MetaClass implements Comparable<MetaClass>
 
 		if (classBytecode == null)
 		{
-			classBytecode = BytecodeLoader.fetchBytecodeForClass(classLocations, getFullyQualifiedName(), true);
+			classBytecode = BytecodeLoader.fetchBytecodeForClass(classLocations, getFullyQualifiedName(), javapPath, true);
 
 			if (classBytecode != null)
 			{

--- a/core/src/main/java/org/adoptopenjdk/jitwatch/process/javap/JavapProcess.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/process/javap/JavapProcess.java
@@ -23,6 +23,11 @@ public class JavapProcess extends AbstractProcess
 
 	private final String EXECUTABLE_NAME = "javap" + getExecutableSuffix();
 
+	public JavapProcess(Path executablePath)
+	{
+		this.executablePath = executablePath;
+	}
+
 	public JavapProcess() throws FileNotFoundException
 	{
 		super();


### PR DESCRIPTION
When running inside IntelliJ IDEA, the java.home system property points to a JRE which doesn't have javap, so we need the ability to pass the path externally.