### PR TITLE
Fix jdk compiler arguments in maven pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,8 +328,10 @@
 					<configuration>
 						<source>${jdk.version}</source>
 						<target>${jdk.version}</target>
-						<compilerArgument>-Xlint:unchecked</compilerArgument>
-						<compilerArgument>-g:source,lines</compilerArgument>
+						<compilerArgs>
+							<arg>-Xlint:all</arg>
+							<arg>-g:source,lines</arg>
+						</compilerArgs>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
Hello everyone, 

A small help :/

According to this doc [mvn compiler](https://maven.apache.org/plugins/maven-compiler-plugin/examples/pass-compiler-arguments.html), the  `compilerArgument` does not work anymore. 

You can test it by adding `List<String> unsafeOperation = new ArrayList();` in your code you will see in the mvn compiler output something asking you to add -Xlint argument. (tested using 3.3.9)

Have a nice day 