### PR TITLE
Updated launch scripts to support any working dir

### DIFF
--- a/launchHeadless.sh
+++ b/launchHeadless.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Get script dir, resolving symlinks; works on Linux and Mac.
+jitwatch_dir=$(python -c '
+from os.path import *
+from sys import *
+print(dirname(realpath(argv[1])))
+' "$0")
+
 unamestr=`uname`
 if [ "$JAVA_HOME" = '' ]; then
   if [ "$unamestr" = 'Darwin' ]; then
@@ -10,11 +17,11 @@ if [ "$JAVA_HOME" = '' ]; then
   fi
 fi
 
-CLASSPATH=$CLASSPATH:lib/logback-classic-1.1.2.jar
-CLASSPATH=$CLASSPATH:lib/logback-core-1.1.2.jar
-CLASSPATH=$CLASSPATH:lib/slf4j-api-1.7.7.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
-CLASSPATH=$CLASSPATH:core/target/classes
-CLASSPATH=$CLASSPATH:ui/target/classes
+CLASSPATH=$CLASSPATH:$jitwatch_dir/lib/logback-classic-1.1.2.jar
+CLASSPATH=$CLASSPATH:$jitwatch_dir/lib/logback-core-1.1.2.jar
+CLASSPATH=$CLASSPATH:$jitwatch_dir/lib/slf4j-api-1.7.7.jar
+CLASSPATH=$CLASSPATH:$jitwatch_dir/core/target/classes
+CLASSPATH=$CLASSPATH:$jitwatch_dir/ui/target/classes
 
 "$JAVA_HOME/bin/java" -cp "$CLASSPATH" org.adoptopenjdk.jitwatch.launch.LaunchHeadless $@

--- a/launchUI.sh
+++ b/launchUI.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# Get script dir, resolving symlinks; works on Linux and Mac.
+jitwatch_dir=$(python -c '
+from os.path import *
+from sys import *
+print(dirname(realpath(argv[1])))
+' "$0")
+
+CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
+
 unamestr=`uname`
 if [ "$JAVA_HOME" = '' ]; then
   if [ "$unamestr" = 'Darwin' ]; then
@@ -19,13 +28,13 @@ fi
 # You may need to set -Xmx (max heap) and -XX:MaxPermSize
 # if your hotspot.log references a lot of classes
 
-CLASSPATH=$CLASSPATH:lib/logback-classic-1.1.2.jar
-CLASSPATH=$CLASSPATH:lib/logback-core-1.1.2.jar
-CLASSPATH=$CLASSPATH:lib/slf4j-api-1.7.7.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/jre/lib/jfxrt.jar
-CLASSPATH=$CLASSPATH:core/target/classes
-CLASSPATH=$CLASSPATH:ui/target/classes
-CLASSPATH=$CLASSPATH:ui/src/main/resources
+CLASSPATH=$CLASSPATH:$jitwatch_dir/lib/logback-classic-1.1.2.jar
+CLASSPATH=$CLASSPATH:$jitwatch_dir/lib/logback-core-1.1.2.jar
+CLASSPATH=$CLASSPATH:$jitwatch_dir/lib/slf4j-api-1.7.7.jar
+CLASSPATH=$CLASSPATH:$jitwatch_dir/core/target/classes
+CLASSPATH=$CLASSPATH:$jitwatch_dir/ui/target/classes
+CLASSPATH=$CLASSPATH:$jitwatch_dir/ui/src/main/resources
 
 "$JAVA_HOME/bin/java" -Djava.library.path=$JAVA_HOME/lib/amd64 -cp "$CLASSPATH" $@ org.adoptopenjdk.jitwatch.launch.LaunchUI


### PR DESCRIPTION
That way, you can launch it from anywhere, not just the jitwatch project directory.