### PR TITLE
Fix Java 11+ builds for Maven and Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,39 +64,6 @@ jacocoTestReport {
 }
 //Code quality plugins configuration end
 
-// we expect jdk to be any of ['jdk7', 'jdk8', 'jdk9']
-// this property can specified at the command line as follows
-//
-//   gradle -Pjdk=jdk8 <command>
-//
-if (!hasProperty('jdk')) {
-    ext.jdk = 'jdk7' // lowest
-}
-
-
-allprojects {
-    configurations {
-        // gradle does not have a 'system' nor 'provided' scope
-        system
-
-        // fix classpaths due to missing 'system' scope
-        sourceSets {
-            main {
-                compileClasspath += configurations.system
-            }
-        }
-    }
-
-    compileJava {
-        //add required JavaFX libs to compile classpath
-        sourceSets.main.compileClasspath += configurations.system
-    }
-
-    test {
-        classpath += configurations.system
-    }
-}
-
 apply from: "gradle/eclipse.gradle"
 
 license {
@@ -116,16 +83,6 @@ license {
 // do not format test resources
 licenseTest {
     source -= sourceSets.test.resources
-}
-
-javadoc {
-    classpath += configurations.system
-}
-
-idea {
-    module {
-        scopes.PROVIDED.plus += configurations.system
-    }
 }
 
 subprojects {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.12', 'ch.qos.logback:logback-classic:1.1.3', 'ch.qos.logback:logback-core:1.1.3'
+    compile 'org.slf4j:slf4j-api:1.7.12', 'ch.qos.logback:logback-classic:1.2.3', 'ch.qos.logback:logback-core:1.2.3'
     testCompile 'junit:junit:4.12'
 }
 

--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -9,4 +9,7 @@ eclipse {
 	}
 }
 
-eclipse.classpath.plusConfigurations += [configurations.system]
+gradle.projectsEvaluated {
+    def systemConfigurations = subprojects.collect { it.configurations.findByName("system") }.findAll { it != null}
+    eclipse.classpath.plusConfigurations += [systemConfigurations]
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip

--- a/ui/build-jdk11.gradle
+++ b/ui/build-jdk11.gradle
@@ -1,0 +1,33 @@
+apply plugin: "org.openjfx.javafxplugin"
+
+def javaVersion = JavaVersion.current()
+def openjfxVersion
+
+if (javaVersion == JavaVersion.VERSION_11) {
+    openjfxVersion = "11.0.2"
+} else if (javaVersion >= JavaVersion.VERSION_12) {
+    openjfxVersion = "12.0.1"
+} else {
+    throw GradleException("Building JITWatch is unsupported on this version of java")
+}
+
+def javafxModules = [
+        'javafx.controls',
+        'javafx.swing',
+        'javafx.web',
+]
+
+javafx {
+    version = openjfxVersion
+    modules = javafxModules
+}
+
+dependencies {
+    javafxModules.each {
+        def javafxModuleArtifact = it.replace(".", "-")
+
+        runtimeOnly "org.openjfx:$javafxModuleArtifact:$javafx.version:linux"
+        runtimeOnly "org.openjfx:$javafxModuleArtifact:$javafx.version:win"
+        runtimeOnly "org.openjfx:$javafxModuleArtifact:$javafx.version:mac"
+    }
+}

--- a/ui/build-jdk7.gradle
+++ b/ui/build-jdk7.gradle
@@ -1,0 +1,61 @@
+def findJavafxRuntime(String path) {
+    if (path == null) {
+        return null
+    }
+
+    def tree = fileTree(dir: path, include: ['**/jfxrt.jar'])
+
+    if (!tree.files.isEmpty()) {
+        return tree.singleFile
+    }
+
+    return null
+}
+
+def potentialJavafxLocations = [
+    System.properties['java.home'],
+    "$rootDir/lib" // Support dropping a JavaFX installation into lib/
+]
+
+def javafxHome = System.properties['javafx.home']
+if (javafxHome != null) {
+    potentialJavafxLocations += javafxHome
+}
+
+def jfxrt = potentialJavafxLocations.collect(this.&findJavafxRuntime).find { it != null}
+
+if (jfxrt == null) {
+    throw new GradleException(
+        """
+Unable to locate a JavaFX runtime in the any of the following locations:
+    
+${potentialJavafxLocations.collect { path -> "\t${path}" }.join("\n")}
+
+Please set the property "javafx.home" to a location containing a JavaFX installation,
+or place the JavaFX runtime into "$rootDir/lib".
+        """
+    )
+}
+
+configurations {
+    // gradle does not have a 'system' nor 'provided' scope
+    system
+}
+
+compileJava {
+     sourceSets.main.compileClasspath += configurations.system
+}
+
+javadoc {
+    classpath += configurations.system
+}
+
+idea {
+    module {
+        scopes.PROVIDED.plus += configurations.system
+    }
+}
+
+dependencies {
+    system(files(jfxrt))
+}

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,61 +1,42 @@
 plugins {
     id 'java'
     id 'application'  	// similar to mvn exec:java
-    id 'com.github.johnrengelman.shadow' version '2.0.1'  // fat jar
     id 'maven-publish'
+    id 'org.openjfx.javafxplugin' version '0.0.8' apply(false)
 }
 
-// detect jfxrt.jar
-ext {
+def javaVersion = JavaVersion.current()
 
-    //fx path on 1.7
-    jfxrtLocation = new File("${System.properties['java.home']}/jre/lib/jfxrt.jar").absolutePath
-
-    switch (JavaVersion.current()){
-        case JavaVersion.VERSION_1_6 :
-            throw new GradleException("Java FX is not supported by Java 1.6 upgrade to 1.7.")
-            break
-        case JavaVersion.VERSION_1_7 :
-            break
-        case JavaVersion.VERSION_1_8 :
-            jfxrtLocation = new File("${System.properties['java.home']}/jre/lib/ext/jfxrt.jar").absolutePath
-            break
-        case JavaVersion.VERSION_1_9 :
-            break
-        default:
-            throw new GradleException("Can't get java version!")
-            break
-    }
-}
-
-for (location in ['lib/jfxrt.jar', 'jre/lib/jfxrt.jar', 'jre/lib/ext/jfxrt.jar']) {
-    File javaHome = new File(System.properties['java.home'])
-    javaHome = javaHome.name == 'jre' ? javaHome.parentFile : javaHome
-    File file = new File(javaHome, location)
-    if (file.exists()) {
-        jfxrtLocation = file.absolutePath
-        break
-    }
+if (javaVersion >= JavaVersion.VERSION_1_7 && javaVersion < JavaVersion.VERSION_1_9) {
+    apply from: "build-jdk7.gradle"
+} else if (javaVersion >= JavaVersion.VERSION_11) {
+    apply from: "build-jdk11.gradle"
+} else {
+    throw new GradleException("JITWatch is unsupported on Java $javaVersion")
 }
 
 dependencies {
     compile project(':core')
 
-    compile 'org.slf4j:slf4j-api:1.7.12', 'ch.qos.logback:logback-classic:1.1.3', 'ch.qos.logback:logback-core:1.1.3'
+    compile 'org.slf4j:slf4j-api:1.7.12', 'ch.qos.logback:logback-classic:1.2.3', 'ch.qos.logback:logback-core:1.2.3'
     testCompile 'junit:junit:4.12'
-    system files(jfxrtLocation)
-}
-
-run {
-    //add required JavaFX libs to runtime classpath
-    classpath += configurations.system
-    workingDir = new File("..")
 }
 
 mainClassName = 'org.adoptopenjdk.jitwatch.launch.LaunchUI'
 
-shadowJar {
-    baseName = 'jitwatch'
+run {
+    workingDir = rootDir
+}
+
+task fatJar(type: Jar) {
+    manifest {
+        attributes 'Main-Class': mainClassName
+    }
+
+    group = 'build'
+    baseName = 'ui-shadow'
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
 }
 
 publishing {

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -41,8 +41,115 @@
 			</dependencies>
 		</profile>
 
-
-		<!-- ======== JDK 11 Profile ======== -->
+		<profile>
+			<id>openjfx</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<dependencies>
+				<!-- https://mvnrepository.com/artifact/org.openjfx/javafx -->
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-controls</artifactId>
+					<version>${openjfx.version}</version>
+					<type>pom</type>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-swing</artifactId>
+					<version>${openjfx.version}</version>
+					<type>pom</type>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-web</artifactId>
+					<version>${openjfx.version}</version>
+					<type>pom</type>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-controls</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>win</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-controls</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>linux</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-controls</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>mac</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-web</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>win</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-web</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>linux</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-web</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>mac</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-swing</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>win</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-swing</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>linux</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-swing</artifactId>
+					<version>${openjfx.version}</version>
+					<classifier>mac</classifier>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.2.0</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<shadedArtifactAttached>true</shadedArtifactAttached>
+									<shadedClassifierName>project-classifier</shadedClassifierName>
+									<outputFile>target/ui-shaded.jar</outputFile>
+									<transformers>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+											<mainClass>${main.class}</mainClass>
+										</transformer>
+									</transformers>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+    <!-- ======== JDK 11 Profile ======== -->
 		<profile>
 			<id>jdk11</id>
 			<activation>
@@ -51,22 +158,8 @@
 			<properties>
 				<jdk.version>11</jdk.version>
 				<javafx.version>11</javafx.version>
+				<openjfx.version>11.0.2</openjfx.version>
 			</properties>
-			<dependencies>
-				<!-- https://mvnrepository.com/artifact/org.openjfx/javafx -->
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-					<version>11.0.1-ea+1</version>
-					<type>pom</type>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-web</artifactId>
-					<version>11.0.1-ea+1</version>
-					<type>pom</type>
-				</dependency>
-			</dependencies>
 		</profile>
 
 		<!-- ======== JDK 12 Profile ======== -->
@@ -77,50 +170,22 @@
 			</activation>
 			<properties>
 				<jdk.version>12</jdk.version>
-				<javafx.version>11</javafx.version>
+				<javafx.version>12</javafx.version>
+				<openjfx.version>12.0.1</openjfx.version>
 			</properties>
-			<dependencies>
-				<!-- https://mvnrepository.com/artifact/org.openjfx/javafx -->
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-					<version>11.0.1-ea+1</version>
-					<type>pom</type>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-web</artifactId>
-					<version>11.0.1-ea+1</version>
-					<type>pom</type>
-				</dependency>
-			</dependencies>
 		</profile>
 
 		<!-- ======== JDK 13 Profile ======== -->
 		<profile>
-			<id>jdk13</id>
+			<id>jdk13-later</id>
 			<activation>
-				<jdk>13</jdk>
+				<jdk>[13,)</jdk>
 			</activation>
 			<properties>
 				<jdk.version>13</jdk.version>
-				<javafx.version>11</javafx.version>
+				<javafx.version>12</javafx.version>
+				<openjfx.version>12.0.1</openjfx.version>
 			</properties>
-			<dependencies>
-				<!-- https://mvnrepository.com/artifact/org.openjfx/javafx -->
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-					<version>11.0.1-ea+1</version>
-					<type>pom</type>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-web</artifactId>
-					<version>11.0.1-ea+1</version>
-					<type>pom</type>
-				</dependency>
-			</dependencies>
 		</profile>
 	</profiles>
 	<!-- ======== Dependencies ======== -->


### PR DESCRIPTION
Currently the Maven POM points to early access builds of OpenJFX which are now (seemingly?) unavailable. I've updated these to use the correct versions under each version of Java, and added a fallback profile to use the latest available for future unreleased versions of Java.

The Gradle build has been updated to support building under both Java 7/8 and Java 11 onwards in the same manner as Maven and some of the root projects build script has been cleaned up to move UI specific configuration into the JDK 7/8 build.

Both build systems are now capable of producing fat jars by using their packaging goal (`gradle assemble`, `mvn package`).

Fixes #308.