### PR TITLE
Fix gradle build error 

### DIFF
--- a/ui/build-jdk7.gradle
+++ b/ui/build-jdk7.gradle
@@ -38,24 +38,9 @@ or place the JavaFX runtime into "$rootDir/lib".
 }
 
 configurations {
-    // gradle does not have a 'system' nor 'provided' scope
-    system
-}
-
-compileJava {
-     sourceSets.main.compileClasspath += configurations.system
-}
-
-javadoc {
-    classpath += configurations.system
-}
-
-idea {
-    module {
-        scopes.PROVIDED.plus += configurations.system
-    }
+    compileOnly
 }
 
 dependencies {
-    system(files(jfxrt))
+    compileOnly(files(jfxrt))
 }


### PR DESCRIPTION
Caused by an eager resolve of custom configuration.
Fixes #315

The `compileOnly` configuration is supported since Gradle 4 and delivers the behavior of the `provided` scope found in Maven.