### PR TITLE
ILogParser allows Readers for processing now.

### DIFF
--- a/core/src/main/java/org/adoptopenjdk/jitwatch/parser/AbstractLogParser.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/parser/AbstractLogParser.java
@@ -30,6 +30,7 @@ import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_TASK;
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_TASK_DONE;
 
 import java.io.File;
+import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -344,7 +345,7 @@ public abstract class AbstractLogParser implements ILogParser
 	}
 
 	@Override
-	public void processLogFile(File logFile, ILogParseErrorListener errorListener)
+	public void processLogFile(Reader logFileReader, ILogParseErrorListener errorListener)
 	{
 		reset();
 
@@ -355,7 +356,7 @@ public abstract class AbstractLogParser implements ILogParser
 
 		this.errorListener = errorListener;
 
-		splitLogFile(logFile);
+		splitLogFile(logFileReader);
 
 		if (DEBUG_LOGGING)
 		{
@@ -540,7 +541,7 @@ public abstract class AbstractLogParser implements ILogParser
 		if (compilation != null)
 		{
 			compilation.setTagTask(tagTask);
-			
+
 			if (currentCompilerThread != null)
 			{
 				currentCompilerThread.addCompilation(compilation);
@@ -671,7 +672,7 @@ public abstract class AbstractLogParser implements ILogParser
 
 	protected abstract void parseLogFile();
 
-	protected abstract void splitLogFile(File logFile);
+	protected abstract void splitLogFile(Reader logFileReader);
 
 	protected abstract void handleTag(Tag tag);
 }

--- a/core/src/main/java/org/adoptopenjdk/jitwatch/parser/ILogParser.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/parser/ILogParser.java
@@ -6,7 +6,9 @@
 package org.adoptopenjdk.jitwatch.parser;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 
 import org.adoptopenjdk.jitwatch.core.JITWatchConfig;
 import org.adoptopenjdk.jitwatch.model.JITDataModel;
@@ -16,24 +18,28 @@ import org.adoptopenjdk.jitwatch.model.SplitLog;
 public interface ILogParser
 {
 	void setConfig(JITWatchConfig config);
-	
-	void processLogFile(File logFile, ILogParseErrorListener listener) throws IOException;
-	
+
+	default void processLogFile(File logFile, ILogParseErrorListener listener) throws IOException{
+		processLogFile(new FileReader(logFile), listener);
+	}
+
+	void processLogFile(Reader logFileReader, ILogParseErrorListener listener) throws IOException;
+
 	SplitLog getSplitLog();
-	
+
 	void stopParsing();
-	
+
 	ParsedClasspath getParsedClasspath();
-	
+
 	JITDataModel getModel();
-	
+
 	JITWatchConfig getConfig();
-	
+
 	void reset();
-		
+
 	boolean hasParseError();
-		
+
 	String getVMCommand();
-	
+
 	void discardParsedLogs();
 }

--- a/core/src/main/java/org/adoptopenjdk/jitwatch/parser/hotspot/HotSpotLogParser.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/parser/hotspot/HotSpotLogParser.java
@@ -42,9 +42,8 @@ import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_HOTSPOT_LOG;
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.ATTR_TIME_MS;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.List;
@@ -182,11 +181,11 @@ public class HotSpotLogParser extends AbstractLogParser
     }
 
     @Override
-    protected void splitLogFile(File hotspotLog)
+    protected void splitLogFile(Reader hotspotLogReader)
     {
         reading = true;
 
-        try (BufferedReader reader = new BufferedReader(new FileReader(hotspotLog), 65536))
+        try (BufferedReader reader = new BufferedReader(hotspotLogReader, 65536))
         {
             String currentLine = reader.readLine();
 

--- a/core/src/main/java/org/adoptopenjdk/jitwatch/parser/j9/J9LogParser.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/parser/j9/J9LogParser.java
@@ -11,9 +11,8 @@ import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_TASK;
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_TASK_QUEUED;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 
 import org.adoptopenjdk.jitwatch.core.IJITListener;
 import org.adoptopenjdk.jitwatch.model.NumberedLine;
@@ -39,47 +38,47 @@ public class J9LogParser extends AbstractLogParser
 			processLineNumber = numberedLine.getLineNumber();
 
 			J9Line j9Line = J9Util.parseLine(numberedLine.getLine());
-			
+
 			if (DEBUG_LOGGING)
 			{
 				logger.debug("J9 log line parsed\n{}", j9Line);
 			}
-			
+
 			Tag tagQueued = j9Line.toTagQueued(compileID, timestampMillis);
 			Tag tagNMethod = j9Line.toTagNMethod(compileID, timestampMillis);
 			Tag tagTask = j9Line.toTagTask(compileID, timestampMillis);
-			
+
 			compileID++;
-			
+
 			timestampMillis++;
-			
+
 			if (tagQueued != null)
 			{
 				handleTag(tagQueued);
 			}
-			
+
 			if (tagNMethod != null)
 			{
 				handleTag(tagNMethod);
 			}
-			
+
 			if (tagTask != null)
 			{
 				handleTag(tagTask);
 			}
 		}
 	}
-	
+
 	@Override
 	protected void handleTag(Tag tag)
 	{
 		String tagName = tag.getName();
-		
+
 		if (DEBUG_LOGGING)
 		{
 			logger.debug("handling {}", tagName);
 		}
-		
+
 		switch (tagName)
 		{
 		case TAG_TASK_QUEUED:
@@ -100,11 +99,11 @@ public class J9LogParser extends AbstractLogParser
 	}
 
 	@Override
-	protected void splitLogFile(File logFile)
+	protected void splitLogFile(Reader logFileReader)
 	{
 		reading = true;
 
-		try (BufferedReader reader = new BufferedReader(new FileReader(logFile), 65536))
+		try (BufferedReader reader = new BufferedReader(logFileReader, 65536))
 		{
 			String currentLine = reader.readLine();
 

--- a/core/src/main/java/org/adoptopenjdk/jitwatch/parser/zing/ZingLogParser.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/parser/zing/ZingLogParser.java
@@ -11,9 +11,8 @@ import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_TASK;
 import static org.adoptopenjdk.jitwatch.core.JITWatchConstants.TAG_TASK_QUEUED;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -347,11 +346,11 @@ public class ZingLogParser extends AbstractLogParser
 	}
 
 	@Override
-	protected void splitLogFile(File logFile)
+	protected void splitLogFile(Reader logFileReader)
 	{
 		reading = true;
 
-		try (BufferedReader reader = new BufferedReader(new FileReader(logFile), 65536))
+		try (BufferedReader reader = new BufferedReader(logFileReader, 65536))
 		{
 			String currentLine = reader.readLine();
 

--- a/core/src/test/java/org/adoptopenjdk/jitwatch/test/UnitTestLogParser.java
+++ b/core/src/test/java/org/adoptopenjdk/jitwatch/test/UnitTestLogParser.java
@@ -1,6 +1,6 @@
 package org.adoptopenjdk.jitwatch.test;
 
-import java.io.File;
+import java.io.Reader;
 
 import org.adoptopenjdk.jitwatch.core.IJITListener;
 import org.adoptopenjdk.jitwatch.model.CompilerThread;
@@ -10,11 +10,11 @@ import org.adoptopenjdk.jitwatch.model.Task;
 import org.adoptopenjdk.jitwatch.parser.AbstractLogParser;
 
 public class UnitTestLogParser extends AbstractLogParser
-{	
+{
 	public UnitTestLogParser(IJITListener jitListener)
 	{
 		super(jitListener);
-		
+
 		currentCompilerThread = new CompilerThread("1234", "TestCompilerThread");
 	}
 
@@ -24,33 +24,33 @@ public class UnitTestLogParser extends AbstractLogParser
 	}
 
 	@Override
-	protected void splitLogFile(File logFile)
+	protected void splitLogFile(Reader logFileReader)
 	{
 	}
 
 	@Override
 	protected void handleTag(Tag tag)
-	{		
+	{
 	}
-	
+
 	@Override
 	public void setTagTaskQueued(Tag tagTaskQueued, IMetaMember metaMember)
 	{
 		super.setTagTaskQueued(tagTaskQueued, metaMember);
 	}
-	
+
 	@Override
 	public void setTagNMethod(Tag tagNMethod, IMetaMember member)
 	{
 		super.setTagNMethod(tagNMethod, member);
 	}
-	
+
 	@Override
 	public void setTagTask(Task tagTask, IMetaMember member)
 	{
 		super.setTagTask(tagTask, member);
 	}
-	
+
 	public void setTagTaskDone(Tag tagTaskDone, IMetaMember member)
 	{
 		super.handleTaskDone(tagTaskDone, member);


### PR DESCRIPTION
Hi,
I'm currently writting an eclipse integration for jitwatch, so that java projects can be launched with jitwatch enabled like e.g. code coverage. 

Therefore I made a little change that makes the API more flexible. E.g. to report progress when reading large input files by passing the ILogFileParser a Reader that is based on a ProgressInputStream.

I also introduced a default method that takes a File in the ILogFileParser for backward compatibility.

Feel free to write me if you have any questions.

Regards
René