### PR TITLE
Updatereadmescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ For pre-JDK11 you will need to use a Java runtime that includes JavaFX.
 
 <h2>Build an example HotSpot log</h2>
 <pre># Build the code and then run
-./makeDemoLogFile.sh</pre>
+cd scripts && ./makeDemoLogFile.sh</pre>

--- a/scripts/makeDemoLogFile.sh
+++ b/scripts/makeDemoLogFile.sh
@@ -70,11 +70,7 @@ echo "VM Switches $REQUIRED_SWITCHES $OPTIONAL_SWITCHES"
 
 echo "Building example HotSpot log"
 
-if [ "$unamestr" = 'Darwin' ]; then
-   export CLASSPATH=../ui/target/jitwatch-ui-shaded-mac.jar
-else
-   export CLASSPATH=../ui/target/jitwatch-ui-shaded.jar
-fi
+export CLASSPATH=../ui/target/jitwatch-ui-shaded.jar
 
 "$JAVA_HOME/bin/java" $REQUIRED_SWITCHES $OPTIONAL_SWITCHES -cp "$CLASSPATH" org.adoptopenjdk.jitwatch.demo.MakeHotSpotLog 2>&1 >/dev/null
 echo "Done"

--- a/scripts/makeDemoLogFile.sh
+++ b/scripts/makeDemoLogFile.sh
@@ -71,9 +71,9 @@ echo "VM Switches $REQUIRED_SWITCHES $OPTIONAL_SWITCHES"
 echo "Building example HotSpot log"
 
 if [ "$unamestr" = 'Darwin' ]; then
-   export CLASSPATH=../ui/target/jitwatch-ui-1.4.4-shaded-mac.jar
+   export CLASSPATH=../ui/target/jitwatch-ui-shaded-mac.jar
 else
-   export CLASSPATH=../ui/target/jitwatch-ui-1.4.4-shaded-linux.jar
+   export CLASSPATH=../ui/target/jitwatch-ui-shaded.jar
 fi
 
 "$JAVA_HOME/bin/java" $REQUIRED_SWITCHES $OPTIONAL_SWITCHES -cp "$CLASSPATH" org.adoptopenjdk.jitwatch.demo.MakeHotSpotLog 2>&1 >/dev/null


### PR DESCRIPTION
It appears that after `makeDemoLogFile.sh` was moved, the  readme wasn't updated to take into account the new location of `makeDemoLogFile.sh`, and that this file wasn't updated to reflect the new location of the jar after building. 

Note: I've tested on linux, but not on MacOS, so I'm making a guess about the jar location there. 

Note: the readme doesn't indicate that you'll need to run mvn clean package, or mvn clean install before running `makeDemoLogFile.sh`. I didn't know how best to indicate that, so I didn't add it. 