### PR TITLE
refactor the @Before/@After to make a test faster

### DIFF
--- a/core/src/test/java/org/adoptopenjdk/jitwatch/test/TestBytecodeLoaderWithInnerClasses.java
+++ b/core/src/test/java/org/adoptopenjdk/jitwatch/test/TestBytecodeLoaderWithInnerClasses.java
@@ -25,8 +25,8 @@ import org.adoptopenjdk.jitwatch.model.bytecode.ClassBC;
 import org.adoptopenjdk.jitwatch.model.bytecode.MemberBytecode;
 import org.adoptopenjdk.jitwatch.model.bytecode.SourceMapper;
 import org.adoptopenjdk.jitwatch.process.compiler.CompilerJava;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /*
@@ -69,19 +69,19 @@ import org.junit.Test;
  */
 public class TestBytecodeLoaderWithInnerClasses
 {
-	private String classNameOuter = "TestInner";
-	private String classNameInner1 = "TestInner$Inner1";
-	private String classNameInner2 = "TestInner$Inner1$Inner2";
+	private static String classNameOuter = "TestInner";
+	private static String classNameInner1 = "TestInner$Inner1";
+	private static String classNameInner2 = "TestInner$Inner1$Inner2";
 
-	private Path pathToSourceDir;
-	private Path pathToTempClassDir;
-	private List<String> classpathLocations;
+	private static Path pathToSourceDir;
+	private static Path pathToTempClassDir;
+	private static List<String> classpathLocations;
 
-	private ClassBC classBytecodeForOuter;
-	private ClassBC classBytecodeForInner1;
-	private ClassBC classBytecodeForInner2;
+	private static ClassBC classBytecodeForOuter;
+	private static ClassBC classBytecodeForInner1;
+	private static ClassBC classBytecodeForInner2;
 
-	@Before public void setUp()
+	@BeforeClass public static void setUp()
 	{
 		try
 		{
@@ -133,7 +133,7 @@ public class TestBytecodeLoaderWithInnerClasses
 		classBytecodeForInner2 = classBytecodeListForOuter.get(2);
 	}
 
-	@After public void tearDown()
+	@AfterClass public static void tearDown()
 	{
 	}
 


### PR DESCRIPTION
The tests in the test class `TestBytecodeLoaderWithInnerClasses` tries to compile a Java file into bytecodes and then uses `BytecodeLoader` to load the compiled bytecodes. However, among all the tests in this test class, there are no modifications on the compiled bytecodes and the fields defined in this test class. 

When running this test, all tests repeatly compile the Java file and load the bytecodes, which add a huge cost to this test. Thus, we propose to just run the @Before and @After method once for the tests in this test class. 

The time to run all the tests in the test class `TestBytecodeLoaderWithInnerClasses` can jump from 4.370 s to 0.491 s on our local machine.