### PR TITLE
Add simple Cursor variant of the DoesItVectorise example

### DIFF
--- a/core/src/main/resources/examples/DoesItVectoriseValue.java
+++ b/core/src/main/resources/examples/DoesItVectoriseValue.java
@@ -1,0 +1,57 @@
+public class DoesItVectoriseValue
+{
+    public DoesItVectoriseValue()
+    {
+        int[] array = new int[1024];
+
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            incrementArray(array, 1);
+        }
+
+        for (int i = 0; i < array.length; i++)
+        {
+            System.out.println(array[i]);
+        }
+    }
+
+    public void incrementArray(int[] array, int constant)
+    {
+        int length = array.length;
+
+        for (Cursor c = Cursor.of(length); c.canAdvance(); c = c.advance())
+        {
+            array[c.position] += constant;
+        }
+    }
+
+    public value record Cursor(int position, int length)
+    {
+        public Cursor {
+            if (length < 0 || position > length)
+            {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        public static Cursor of(int length)
+        {
+            return new Cursor(0, length);
+        }
+
+        public boolean canAdvance()
+        {
+            return position < length;
+        }
+
+        public Cursor advance()
+        {
+            return new Cursor(position + 1, length);
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        new DoesItVectoriseValue();
+    }
+}


### PR DESCRIPTION
Open for discussion. Trying to find some good minimal Valhalla examples, this seemed to be a good start. I'm also looking into adding the "canonical" "Color" and "USDCurrency" examples.

This obviously needs the Valhalla early access JDK and

```
--enable-preview
-Djava.util.WeakHashMap.valueKeyRetention=SOFT
```

in `.mvn/jvm.config` to run via `mvn exec:java` (see https://github.com/AdoptOpenJDK/jitwatch/issues/390 for valueKeyRetention) as well as an appropriately configured sandbox.

I tried the same with `LocalDate`, but the interactions apparently were too complex for vectorization to kick in and using an explicitly declared value class makes it easier to play with just removing `value`.