### PR TITLE
Fix incorrect method categorization in MetaClass.

### DIFF
--- a/core/src/main/java/org/adoptopenjdk/jitwatch/model/MetaClass.java
+++ b/core/src/main/java/org/adoptopenjdk/jitwatch/model/MetaClass.java
@@ -221,11 +221,11 @@ public class MetaClass implements Comparable<MetaClass>
 	{
 		if (member instanceof MetaConstructor)
 		{
-			classMethods.add(member);
+			classConstructors.add(member);
 		}
 		else
 		{
-			classConstructors.add(member);
+			classMethods.add(member);
 		}
 	}
 


### PR DESCRIPTION
I noticed this obvious error, but it probably doesn't affect anything.